### PR TITLE
docs(content-ai): consumer guides, contributor READMEs & typedoc reference

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,11 +13,9 @@ on:
       - ".github/workflows/docs.yml"
   workflow_dispatch:
 
-# Allow the workflow to publish to GitHub Pages.
+# Least privilege at the workflow level; the deploy job widens scope for itself.
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 # One in-flight deploy at a time; don't cancel a running publish.
 concurrency:
@@ -28,9 +26,13 @@ jobs:
   build:
     name: Build docs
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       # pnpm version read from package.json's `packageManager` field.
       - name: Setup pnpm
@@ -63,6 +65,10 @@ jobs:
     name: Deploy to Pages
     needs: build
     runs-on: ubuntu-latest
+    # Pages deployment is the only step that needs these scopes.
+    permissions:
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,72 @@
+name: Docs – content-ai
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "packages/content-ai-core/**"
+      - "packages/content-ai-ingest/**"
+      - "packages/content-ai-refine/**"
+      - "docs/content-ai/**"
+      - "typedoc.json"
+      - "tsconfig.typedoc.json"
+      - ".github/workflows/docs.yml"
+  workflow_dispatch:
+
+# Allow the workflow to publish to GitHub Pages.
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# One in-flight deploy at a time; don't cancel a running publish.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build docs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      # pnpm version read from package.json's `packageManager` field.
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # Generates the typedoc API reference into docs/content-ai/api/
+      # (gitignored — built fresh here). The hand-authored guides under
+      # docs/content-ai/ are already in the checkout.
+      - name: Build API reference
+        run: pnpm exec typedoc
+
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/content-ai
+
+  deploy:
+    name: Deploy to Pages
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ packages/*/src/**/*.d.ts
 
 # Source artifact store (content-addressed, copyrighted binaries, not for git)
 **/data/sources/
+
+# Generated typedoc API reference (regenerated via `vp run docs:api` / CI)
+docs/content-ai/api/

--- a/docs/content-ai/control-flow.html
+++ b/docs/content-ai/control-flow.html
@@ -9,6 +9,19 @@
       import mermaid from "https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs";
       mermaid.initialize({ startOnLoad: true, theme: "neutral", securityLevel: "loose" });
     </script>
+    <script type="module">
+      // Syntax-highlight every code block with Shiki (loads langs/themes on demand).
+      // Mermaid blocks are `pre.mermaid` with no <code> child, so they're skipped.
+      import { codeToHtml } from "https://esm.sh/shiki@3.0.0";
+      for (const code of document.querySelectorAll("pre:not(.mermaid) > code")) {
+        const text = code.textContent ?? "";
+        const firstLine = text.trimStart().split("\n", 1)[0];
+        const lang = firstLine.startsWith("#") || /\bpnpm add\b/.test(text) ? "bash" : "tsx";
+        const html = await codeToHtml(text, { lang, theme: "github-dark" });
+        const inner = new DOMParser().parseFromString(html, "text/html").querySelector("code");
+        if (inner) code.innerHTML = inner.innerHTML;
+      }
+    </script>
     <style>
       .seam {
         stroke-dasharray: 5 4;
@@ -42,6 +55,12 @@
             aria-current="page"
             class="block px-2 py-1 rounded font-semibold text-slate-900 bg-slate-100"
             >End-to-end control flow</a
+          >
+          <p class="text-[11px] uppercase tracking-wider text-slate-400 pt-4 pb-1 px-2">
+            Integrate
+          </p>
+          <a href="integration.html" class="block px-2 py-1 rounded text-slate-600"
+            >Integration walkthrough</a
           >
           <p class="text-[11px] uppercase tracking-wider text-slate-400 pt-4 pb-1 px-2">
             Reference

--- a/docs/content-ai/control-flow.html
+++ b/docs/content-ai/control-flow.html
@@ -1,0 +1,228 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>content-ai — end-to-end control flow</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script type="module">
+      import mermaid from "https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs";
+      mermaid.initialize({ startOnLoad: true, theme: "neutral", securityLevel: "loose" });
+    </script>
+    <style>
+      .seam {
+        stroke-dasharray: 5 4;
+      }
+      .deep {
+        background: linear-gradient(135deg, #0f172a, #1e293b);
+      }
+      .font-serif {
+        font-family: ui-serif, Georgia, Cambria, "Times New Roman", serif;
+      }
+    </style>
+  </head>
+  <body class="bg-stone-50 text-slate-900 font-sans antialiased">
+    <div class="flex min-h-screen">
+      <aside
+        class="hidden md:flex flex-col w-60 shrink-0 border-r border-slate-200 bg-white/60 px-5 py-8 sticky top-0 h-screen"
+      >
+        <p class="font-serif text-lg font-semibold"><a href="index.html">content-ai</a></p>
+        <p class="text-xs text-slate-400 mb-6">AI content substrate</p>
+        <nav class="text-sm space-y-1">
+          <a href="index.html" class="block px-2 py-1 rounded text-slate-600">Overview</a>
+          <p class="text-[11px] uppercase tracking-wider text-slate-400 pt-4 pb-1 px-2">Guides</p>
+          <a href="core.html" class="block px-2 py-1 rounded text-slate-600">core — substrate</a>
+          <a href="ingest.html" class="block px-2 py-1 rounded text-slate-600">ingest — runFill</a>
+          <a href="refine.html" class="block px-2 py-1 rounded text-slate-600"
+            >refine — runRefine / runRefresh</a
+          >
+          <p class="text-[11px] uppercase tracking-wider text-slate-400 pt-4 pb-1 px-2">Flow</p>
+          <a
+            href="control-flow.html"
+            aria-current="page"
+            class="block px-2 py-1 rounded font-semibold text-slate-900 bg-slate-100"
+            >End-to-end control flow</a
+          >
+          <p class="text-[11px] uppercase tracking-wider text-slate-400 pt-4 pb-1 px-2">
+            Reference
+          </p>
+          <a href="api/index.html" class="block px-2 py-1 rounded text-slate-600"
+            >API reference ↗</a
+          >
+        </nav>
+      </aside>
+
+      <main class="flex-1 max-w-4xl mx-auto px-6 py-12 space-y-16">
+        <header class="space-y-3">
+          <p class="text-xs uppercase tracking-[0.2em] text-slate-400">End-to-end</p>
+          <h1 class="text-4xl font-serif font-semibold">Control flow</h1>
+          <p class="text-lg text-slate-600 max-w-2xl">
+            How a request becomes a suggestion — and where the boundary between your app and the
+            substrate sits at every step.
+          </p>
+        </header>
+
+        <!-- 1. THE SEAM (lead) -->
+        <section class="space-y-5">
+          <div class="flex items-baseline gap-3">
+            <span class="font-serif text-3xl font-semibold text-slate-300">1</span>
+            <h2 class="text-2xl font-serif font-semibold">
+              The boundary: what you supply vs what it owns
+            </h2>
+          </div>
+          <p class="text-sm text-slate-600 max-w-3xl">
+            Start here. The substrate is deliberately <strong>I/O-free</strong>. You supply a
+            description of your entity and a way to write results back; it owns prompt assembly,
+            model calls, fingerprinting, suppression, and the auto-apply decision. Nothing else
+            crosses the line. This is what lets two unrelated apps (Spicemixer, pixelmord-hq) share
+            the same runners — ADR 0017, ADR 0020.
+          </p>
+          <div class="grid md:grid-cols-2 gap-4">
+            <div class="rounded-xl border border-slate-200 bg-white p-5">
+              <p class="text-xs uppercase tracking-wider text-slate-400 mb-3">You supply</p>
+              <ul class="text-sm text-slate-700 space-y-2">
+                <li>
+                  <code class="text-xs">AiContract</code> /
+                  <code class="text-xs">IngestContract</code> — schema, field prompts, presets,
+                  policies
+                </li>
+                <li><code class="text-xs">AiConfig</code> — provider base URL, key, model</li>
+                <li>
+                  <code class="text-xs">assemble()</code> — the only place store + event-log writes
+                  happen
+                </li>
+                <li><code class="text-xs">events</code> — rejection history for suppression</li>
+                <li><code class="text-xs">sinks</code> — trace destinations (optional)</li>
+              </ul>
+            </div>
+            <div class="rounded-xl deep text-stone-100 p-5">
+              <p class="text-xs uppercase tracking-wider text-slate-400 mb-3">The substrate owns</p>
+              <ul class="text-sm text-slate-200 space-y-2">
+                <li>Prompt assembly &amp; field gating</li>
+                <li>The LLM call &amp; structured-output parsing</li>
+                <li>Fingerprinting &amp; suppression filtering</li>
+                <li>The auto-apply vs suggestion decision</li>
+                <li>
+                  Trace emission via the ambient <code class="text-xs text-slate-300">Origin</code>
+                </li>
+              </ul>
+              <p class="text-xs text-slate-400 mt-3">
+                It returns data. It never reads or writes your storage.
+              </p>
+            </div>
+          </div>
+        </section>
+
+        <!-- 2. THREE ENTRY POINTS -->
+        <section class="space-y-5">
+          <div class="flex items-baseline gap-3">
+            <span class="font-serif text-3xl font-semibold text-slate-300">2</span>
+            <h2 class="text-2xl font-serif font-semibold">Three ways content enters a field</h2>
+          </div>
+
+          <div class="rounded-lg border border-slate-200 bg-white p-4 space-y-2">
+            <p class="text-sm font-semibold">runFill — source-driven (content-ai-ingest)</p>
+            <pre class="mermaid">
+flowchart LR
+  SRC["source<br/>(pdf / image / text / sibling-locale)"] --> BM["buildMessages"]
+  BM --> LLM["one structured call<br/>over the whole schema"]
+  LLM --> SPLIT{"per field:<br/>write policy"}
+  SPLIT --> SUG["suggestions"]
+  SPLIT --> AA["autoApplied"]
+  LLM --> IE["ingestedEvent"]
+  classDef deep fill:#0f172a,color:#e2e8f0,stroke:#0f172a;
+  class LLM deep
+            </pre>
+          </div>
+
+          <div class="rounded-lg border border-slate-200 bg-white p-4 space-y-2">
+            <p class="text-sm font-semibold">
+              runRefine — prompt-driven, per field (content-ai-refine)
+            </p>
+            <pre class="mermaid">
+flowchart LR
+  TGT["target fields"] --> LOOP["concurrently, per field"]
+  LOOP --> SP["systemPrompt(ctx)<br/>empty ⇒ gated off"]
+  SP --> CALL["LLM → { value, confidence }"]
+  CALL --> SUP{"suppressed?"}
+  SUP -->|no| DEC{"auto-apply?"}
+  DEC --> SUG2["suggestions"]
+  DEC --> AA2["autoApplied"]
+  classDef deep fill:#0f172a,color:#e2e8f0,stroke:#0f172a;
+  class CALL deep
+            </pre>
+          </div>
+
+          <div class="rounded-lg border border-slate-200 bg-white p-4 space-y-2">
+            <p class="text-sm font-semibold">runRefresh — orchestration over runRefine</p>
+            <pre class="mermaid">
+flowchart LR
+  TR["compute target<br/>(missing + bulk)"] --> DR["drive runRefine"]
+  DR --> ER{"errors &amp; nothing<br/>produced?"}
+  ER -->|yes| THR["throw"]
+  ER -->|no| ASM["your assemble()"]
+  ASM --> IO["store + event writes"]
+  classDef seam fill:#fff,stroke:#475569,stroke-dasharray:5 4;
+  class ASM seam
+            </pre>
+          </div>
+          <p class="text-xs text-slate-500">
+            See the
+            <a href="ingest.html" class="text-slate-900 underline underline-offset-2">ingest</a> and
+            <a href="refine.html" class="text-slate-900 underline underline-offset-2">refine</a>
+            guides for each in full.
+          </p>
+        </section>
+
+        <!-- 3. FEEDBACK LOOP -->
+        <section class="space-y-5">
+          <div class="flex items-baseline gap-3">
+            <span class="font-serif text-3xl font-semibold text-slate-300">3</span>
+            <h2 class="text-2xl font-serif font-semibold">
+              The feedback loop: events, suppression, auto-apply
+            </h2>
+          </div>
+          <p class="text-sm text-slate-600 max-w-3xl">
+            Review decisions feed back into the next run. When a human rejects a suggestion you
+            append a <code>rejected</code> event; its fingerprint suppresses that exact proposal
+            forever after. Accepted and auto-applied writes are recorded too — and the auto-apply
+            gate (a confidence threshold, ADR 0004) decides which suggestions never needed review in
+            the first place.
+          </p>
+          <div class="rounded-lg border border-slate-200 bg-white p-4">
+            <pre class="mermaid">
+flowchart TB
+  RUN["runRefine / runFill"] --> SUGG["suggestion (field + fingerprint)"]
+  SUGG --> GATE{"confidence ≥ threshold?"}
+  GATE -->|yes| AUTO["auto-applied → write"]
+  GATE -->|no| REVIEW["surfaced for review"]
+  REVIEW -->|accept| ACC["accepted → write"]
+  REVIEW -->|reject| REJ["rejected event"]
+  AUTO --> LOG[("AI event log")]
+  ACC --> LOG
+  REJ --> LOG
+  LOG -. "next run reads events" .-> SUPP["suppression filters<br/>identical fingerprints"]
+  SUPP -. feeds .-> RUN
+  classDef deep fill:#0f172a,color:#e2e8f0,stroke:#0f172a;
+  class RUN deep
+            </pre>
+          </div>
+          <div
+            class="rounded-md bg-amber-50 border border-amber-200 text-amber-900 text-sm px-4 py-3"
+          >
+            <span class="font-semibold">Where the loop closes is your code.</span> The runner emits
+            suggestions and reads the <code>events</code> you pass in, but appending accept/reject/
+            auto-apply events is a write — so it happens in <code>assemble</code> or your action
+            handler, never inside the substrate.
+          </div>
+        </section>
+
+        <footer class="pt-8 border-t border-slate-200 text-xs text-slate-400">
+          Next: the
+          <a href="api/index.html" class="underline underline-offset-2">API reference</a> for exact
+          signatures.
+        </footer>
+      </main>
+    </div>
+  </body>
+</html>

--- a/docs/content-ai/core.html
+++ b/docs/content-ai/core.html
@@ -1,0 +1,256 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>content-ai-core — the substrate</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script type="module">
+      import mermaid from "https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs";
+      mermaid.initialize({ startOnLoad: true, theme: "neutral", securityLevel: "loose" });
+    </script>
+    <style>
+      .seam {
+        stroke-dasharray: 5 4;
+      }
+      .deep {
+        background: linear-gradient(135deg, #0f172a, #1e293b);
+      }
+      .font-serif {
+        font-family: ui-serif, Georgia, Cambria, "Times New Roman", serif;
+      }
+    </style>
+  </head>
+  <body class="bg-stone-50 text-slate-900 font-sans antialiased">
+    <div class="flex min-h-screen">
+      <aside
+        class="hidden md:flex flex-col w-60 shrink-0 border-r border-slate-200 bg-white/60 px-5 py-8 sticky top-0 h-screen"
+      >
+        <p class="font-serif text-lg font-semibold"><a href="index.html">content-ai</a></p>
+        <p class="text-xs text-slate-400 mb-6">AI content substrate</p>
+        <nav class="text-sm space-y-1">
+          <a href="index.html" class="block px-2 py-1 rounded text-slate-600">Overview</a>
+          <p class="text-[11px] uppercase tracking-wider text-slate-400 pt-4 pb-1 px-2">Guides</p>
+          <a
+            href="core.html"
+            aria-current="page"
+            class="block px-2 py-1 rounded font-semibold text-slate-900 bg-slate-100"
+            >core — substrate</a
+          >
+          <a href="ingest.html" class="block px-2 py-1 rounded text-slate-600">ingest — runFill</a>
+          <a href="refine.html" class="block px-2 py-1 rounded text-slate-600"
+            >refine — runRefine / runRefresh</a
+          >
+          <p class="text-[11px] uppercase tracking-wider text-slate-400 pt-4 pb-1 px-2">Flow</p>
+          <a href="control-flow.html" class="block px-2 py-1 rounded text-slate-600"
+            >End-to-end control flow</a
+          >
+          <p class="text-[11px] uppercase tracking-wider text-slate-400 pt-4 pb-1 px-2">
+            Reference
+          </p>
+          <a
+            href="api/modules/content-ai-core_src.html"
+            class="block px-2 py-1 rounded text-slate-600"
+            >core API ↗</a
+          >
+        </nav>
+      </aside>
+
+      <main class="flex-1 max-w-4xl mx-auto px-6 py-12 space-y-14">
+        <header class="space-y-3">
+          <p class="text-xs uppercase tracking-[0.2em] text-slate-400">Guide · package</p>
+          <h1 class="text-4xl font-serif font-semibold">content-ai-core</h1>
+          <p class="text-lg text-slate-600 max-w-2xl">
+            The shared substrate every runner builds on: the contract vocabulary, the AI event log,
+            fingerprinting, the provider factory with tracing, and presentation helpers. You rarely
+            call core directly — you author types it defines and read results it shapes.
+          </p>
+        </header>
+
+        <!-- ENTRY POINTS -->
+        <section class="space-y-4">
+          <h2 class="text-2xl font-serif font-semibold">Entry points</h2>
+          <p class="text-sm text-slate-600 max-w-3xl">
+            Core splits its surface so browser bundles never pull in Node-only code. The
+            <code>/server</code> and <code>/testing</code> entries use
+            <code>node:async_hooks</code>.
+          </p>
+          <div class="overflow-x-auto">
+            <table class="w-full text-sm border border-slate-200 rounded-lg overflow-hidden">
+              <thead class="bg-slate-50 text-left text-slate-500">
+                <tr>
+                  <th class="px-3 py-2 font-medium">Import</th>
+                  <th class="px-3 py-2 font-medium">Contains</th>
+                  <th class="px-3 py-2 font-medium">Env</th>
+                </tr>
+              </thead>
+              <tbody class="divide-y divide-slate-100 font-mono text-xs">
+                <tr>
+                  <td class="px-3 py-2">@pixelmord/content-ai-core</td>
+                  <td class="px-3 py-2 font-sans">
+                    Contract types, events + suppression, hashing, translation/field-diff, logger,
+                    errors
+                  </td>
+                  <td class="px-3 py-2">isomorphic</td>
+                </tr>
+                <tr>
+                  <td class="px-3 py-2">…/server</td>
+                  <td class="px-3 py-2 font-sans">
+                    Origin (ALS), tracing middleware, <code>createProvider</code>,
+                    <code>resolveConfig</code>
+                  </td>
+                  <td class="px-3 py-2 text-rose-600">node</td>
+                </tr>
+                <tr>
+                  <td class="px-3 py-2">…/testing</td>
+                  <td class="px-3 py-2 font-sans">
+                    <code>InMemoryAiEventLog</code>, <code>InMemoryTraceSink</code>, mock model
+                  </td>
+                  <td class="px-3 py-2 text-rose-600">node</td>
+                </tr>
+                <tr>
+                  <td class="px-3 py-2">…/presentation</td>
+                  <td class="px-3 py-2 font-sans">
+                    <code>summarizeSuggestion</code>, <code>formatConfidence</code>, grouping
+                    helpers
+                  </td>
+                  <td class="px-3 py-2">isomorphic</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        <!-- CONCEPTS -->
+        <section class="space-y-5">
+          <h2 class="text-2xl font-serif font-semibold">Core concepts</h2>
+
+          <div class="rounded-xl border border-slate-200 bg-white p-5 space-y-2">
+            <p class="font-serif text-lg font-semibold">AiContract — the object you author</p>
+            <p class="text-sm text-slate-600">
+              A contract pairs a Zod <code>schema</code> with per-field AI behavior. Each
+              <code>FieldConfig</code> says how to prompt (<code>systemPrompt</code>), what JSON to
+              ask for (<code>outputSchema</code>), whether a result may auto-apply
+              (<code>autoApply</code>), how it interacts with an existing value
+              (<code>writePolicy</code>), and how it behaves under translation. A
+              <code>systemPrompt</code> that returns <code>""</code> <em>gates the field off</em> —
+              that is how preconditions like “no inventory ⇒ no pairings” are expressed.
+            </p>
+            <pre
+              class="rounded-lg bg-slate-900 text-slate-100 text-xs p-4 overflow-x-auto mt-2"
+            ><code>import type { AiContract } from "@pixelmord/content-ai-core";
+
+const recipeContract: AiContract&lt;typeof recipeSchema&gt; = {
+  schema: recipeSchema,
+  presets: [expandPreset, summarizePreset],
+  fields: {
+    description: {
+      systemPrompt: (ctx) =&gt; `Write a description for ${ctx.currentData?.name}.`,
+      autoApply: { policy: "high-confidence", threshold: 1.0 },
+      writePolicy: "fill-if-empty",
+    },
+    pairings: {
+      bulk: true, // attempted on every full refresh
+      systemPrompt: (ctx) =&gt;
+        ctx.sourceContext?.inventory.length ? PAIRING_PROMPT : "", // gated
+    },
+  },
+};</code></pre>
+          </div>
+
+          <div class="grid md:grid-cols-2 gap-4">
+            <div class="rounded-xl border border-slate-200 bg-white p-5 space-y-2">
+              <p class="font-serif text-lg font-semibold">Event log &amp; suppression</p>
+              <p class="text-sm text-slate-600">
+                <code>AiEventLog</code> is an append-only history per entity
+                (<code>EntityRef</code>). Core stamps <code>id</code> and <code>at</code>.
+                <code>rejected</code> and <code>ingested</code> events are never pruned — the former
+                drives <strong>suppression</strong> (a re-proposed identical suggestion is filtered
+                by fingerprint), the latter records source attribution (ADR 0004 / 0012).
+              </p>
+              <p class="text-xs text-slate-500">
+                <code>isSuppressed</code> · <code>filterSuggestions</code> ·
+                <code>buildRejectedContext</code> · <code>recordAiEvent</code>
+              </p>
+            </div>
+            <div class="rounded-xl border border-slate-200 bg-white p-5 space-y-2">
+              <p class="font-serif text-lg font-semibold">Fingerprinting</p>
+              <p class="text-sm text-slate-600">
+                <code>fingerprintHash</code> normalizes a value (trim/lowercase strings, sort keys,
+                recurse arrays) then takes a short SHA-256. Cosmetically different values hash
+                identically — the basis for dedup and suppression. <code>hashContent</code> gives a
+                full-length hash for per-field staleness diffing.
+              </p>
+              <p class="text-xs text-slate-500">
+                <code>fingerprintHash</code> · <code>hashContent</code> ·
+                <code>diffFieldHashes</code>
+              </p>
+            </div>
+            <div class="rounded-xl border border-slate-200 bg-white p-5 space-y-2">
+              <p class="font-serif text-lg font-semibold">
+                Provider &amp; tracing
+                <span class="text-xs font-sans font-normal text-rose-600">/server</span>
+              </p>
+              <p class="text-sm text-slate-600">
+                <code>createProvider(config, { sinks })</code> builds the language model. With
+                <code>sinks</code>, it wraps the model in <code>tracingMiddleware</code> so every
+                call emits a <code>TraceEvent</code> tagged with the ambient
+                <code>Origin</code> (carried via async-local storage). Set
+                <code>AI_PROVIDER=mock</code> for the synthesizing e2e model.
+              </p>
+              <p class="text-xs text-slate-500">
+                <code>createProvider</code> · <code>resolveConfig</code> ·
+                <code>wrapWithOrigin</code> · <code>TraceSink</code>
+              </p>
+            </div>
+            <div class="rounded-xl border border-slate-200 bg-white p-5 space-y-2">
+              <p class="font-serif text-lg font-semibold">
+                Translation &amp; refresh classification
+              </p>
+              <p class="text-sm text-slate-600">
+                <code>TranslationBehavior</code> declares per-field translate / copy / localize /
+                skip. <code>classifyRefreshKind</code> reads those modes against a set of stale
+                fields: all-<code>copy</code> ⇒ <code>silent</code>, otherwise
+                <code>review-required</code> (ADR 0015).
+              </p>
+              <p class="text-xs text-slate-500">
+                <code>resolveTranslation</code> · <code>classifyRefreshKind</code>
+              </p>
+            </div>
+          </div>
+        </section>
+
+        <div
+          class="rounded-md bg-amber-50 border border-amber-200 text-amber-900 text-sm px-4 py-3"
+        >
+          <span class="font-semibold">Type ownership.</span> Core is the single source of truth for
+          the shared types (ADR 0017). The runner packages re-export them so you can import from the
+          runtime package you already depend on — but there is one definition, not divergent copies.
+        </div>
+
+        <footer class="pt-8 border-t border-slate-200 text-xs text-slate-400">
+          Full symbol reference:
+          <a href="api/modules/content-ai-core_src.html" class="underline underline-offset-2"
+            >core</a
+          >
+          ·
+          <a href="api/modules/content-ai-core_src_server.html" class="underline underline-offset-2"
+            >/server</a
+          >
+          ·
+          <a
+            href="api/modules/content-ai-core_src_testing.html"
+            class="underline underline-offset-2"
+            >/testing</a
+          >
+          ·
+          <a
+            href="api/modules/content-ai-core_src_presentation.html"
+            class="underline underline-offset-2"
+            >/presentation</a
+          >
+        </footer>
+      </main>
+    </div>
+  </body>
+</html>

--- a/docs/content-ai/core.html
+++ b/docs/content-ai/core.html
@@ -9,6 +9,19 @@
       import mermaid from "https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs";
       mermaid.initialize({ startOnLoad: true, theme: "neutral", securityLevel: "loose" });
     </script>
+    <script type="module">
+      // Syntax-highlight every code block with Shiki (loads langs/themes on demand).
+      // Mermaid blocks are `pre.mermaid` with no <code> child, so they're skipped.
+      import { codeToHtml } from "https://esm.sh/shiki@3.0.0";
+      for (const code of document.querySelectorAll("pre:not(.mermaid) > code")) {
+        const text = code.textContent ?? "";
+        const firstLine = text.trimStart().split("\n", 1)[0];
+        const lang = firstLine.startsWith("#") || /\bpnpm add\b/.test(text) ? "bash" : "tsx";
+        const html = await codeToHtml(text, { lang, theme: "github-dark" });
+        const inner = new DOMParser().parseFromString(html, "text/html").querySelector("code");
+        if (inner) code.innerHTML = inner.innerHTML;
+      }
+    </script>
     <style>
       .seam {
         stroke-dasharray: 5 4;
@@ -44,6 +57,12 @@
           <p class="text-[11px] uppercase tracking-wider text-slate-400 pt-4 pb-1 px-2">Flow</p>
           <a href="control-flow.html" class="block px-2 py-1 rounded text-slate-600"
             >End-to-end control flow</a
+          >
+          <p class="text-[11px] uppercase tracking-wider text-slate-400 pt-4 pb-1 px-2">
+            Integrate
+          </p>
+          <a href="integration.html" class="block px-2 py-1 rounded text-slate-600"
+            >Integration walkthrough</a
           >
           <p class="text-[11px] uppercase tracking-wider text-slate-400 pt-4 pb-1 px-2">
             Reference

--- a/docs/content-ai/index.html
+++ b/docs/content-ai/index.html
@@ -9,6 +9,19 @@
       import mermaid from "https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs";
       mermaid.initialize({ startOnLoad: true, theme: "neutral", securityLevel: "loose" });
     </script>
+    <script type="module">
+      // Syntax-highlight every code block with Shiki (loads langs/themes on demand).
+      // Mermaid blocks are `pre.mermaid` with no <code> child, so they're skipped.
+      import { codeToHtml } from "https://esm.sh/shiki@3.0.0";
+      for (const code of document.querySelectorAll("pre:not(.mermaid) > code")) {
+        const text = code.textContent ?? "";
+        const firstLine = text.trimStart().split("\n", 1)[0];
+        const lang = firstLine.startsWith("#") || /\bpnpm add\b/.test(text) ? "bash" : "tsx";
+        const html = await codeToHtml(text, { lang, theme: "github-dark" });
+        const inner = new DOMParser().parseFromString(html, "text/html").querySelector("code");
+        if (inner) code.innerHTML = inner.innerHTML;
+      }
+    </script>
     <style>
       .seam {
         stroke-dasharray: 5 4;
@@ -53,6 +66,12 @@
           <p class="text-[11px] uppercase tracking-wider text-slate-400 pt-4 pb-1 px-2">Flow</p>
           <a x-nav href="control-flow.html" class="block px-2 py-1 rounded text-slate-600"
             >End-to-end control flow</a
+          >
+          <p class="text-[11px] uppercase tracking-wider text-slate-400 pt-4 pb-1 px-2">
+            Integrate
+          </p>
+          <a x-nav href="integration.html" class="block px-2 py-1 rounded text-slate-600"
+            >Integration walkthrough</a
           >
           <p class="text-[11px] uppercase tracking-wider text-slate-400 pt-4 pb-1 px-2">
             Reference

--- a/docs/content-ai/index.html
+++ b/docs/content-ai/index.html
@@ -1,0 +1,247 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>content-ai — substrate for AI-assisted content</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script type="module">
+      import mermaid from "https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs";
+      mermaid.initialize({ startOnLoad: true, theme: "neutral", securityLevel: "loose" });
+    </script>
+    <style>
+      .seam {
+        stroke-dasharray: 5 4;
+      }
+      .deep {
+        background: linear-gradient(135deg, #0f172a, #1e293b);
+      }
+      .font-serif {
+        font-family: ui-serif, Georgia, Cambria, "Times New Roman", serif;
+      }
+      [x-nav]:hover {
+        color: #0f172a;
+      }
+    </style>
+  </head>
+  <body class="bg-stone-50 text-slate-900 font-sans antialiased">
+    <div class="flex min-h-screen">
+      <!-- ============ SIDEBAR ============ -->
+      <aside
+        class="hidden md:flex flex-col w-60 shrink-0 border-r border-slate-200 bg-white/60 px-5 py-8 sticky top-0 h-screen"
+      >
+        <p class="font-serif text-lg font-semibold">content-ai</p>
+        <p class="text-xs text-slate-400 mb-6">AI content substrate</p>
+        <nav class="text-sm space-y-1">
+          <a
+            x-nav
+            href="index.html"
+            aria-current="page"
+            class="block px-2 py-1 rounded font-semibold text-slate-900 bg-slate-100"
+            >Overview</a
+          >
+          <p class="text-[11px] uppercase tracking-wider text-slate-400 pt-4 pb-1 px-2">Guides</p>
+          <a x-nav href="core.html" class="block px-2 py-1 rounded text-slate-600"
+            >core — substrate</a
+          >
+          <a x-nav href="ingest.html" class="block px-2 py-1 rounded text-slate-600"
+            >ingest — runFill</a
+          >
+          <a x-nav href="refine.html" class="block px-2 py-1 rounded text-slate-600"
+            >refine — runRefine / runRefresh</a
+          >
+          <p class="text-[11px] uppercase tracking-wider text-slate-400 pt-4 pb-1 px-2">Flow</p>
+          <a x-nav href="control-flow.html" class="block px-2 py-1 rounded text-slate-600"
+            >End-to-end control flow</a
+          >
+          <p class="text-[11px] uppercase tracking-wider text-slate-400 pt-4 pb-1 px-2">
+            Reference
+          </p>
+          <a x-nav href="api/index.html" class="block px-2 py-1 rounded text-slate-600"
+            >API reference ↗</a
+          >
+        </nav>
+      </aside>
+
+      <!-- ============ MAIN ============ -->
+      <main class="flex-1 max-w-4xl mx-auto px-6 py-12 space-y-14">
+        <header class="space-y-4">
+          <p class="text-xs uppercase tracking-[0.2em] text-slate-400">Consumer documentation</p>
+          <h1 class="text-4xl font-serif font-semibold">content-ai</h1>
+          <p class="text-lg text-slate-600 max-w-2xl">
+            A pluggable substrate for AI-assisted content suggestion: fill entities from sources,
+            refine them field-by-field, and orchestrate full refreshes — while your app keeps
+            ownership of storage, review, and side effects.
+          </p>
+          <div class="flex flex-wrap gap-2 text-xs pt-1">
+            <span class="px-2.5 py-1 rounded-full bg-slate-100 text-slate-600 font-mono"
+              >@pixelmord/content-ai-core</span
+            >
+            <span class="px-2.5 py-1 rounded-full bg-slate-100 text-slate-600 font-mono"
+              >@pixelmord/content-ai-ingest</span
+            >
+            <span class="px-2.5 py-1 rounded-full bg-slate-100 text-slate-600 font-mono"
+              >@pixelmord/content-ai-refine</span
+            >
+          </div>
+        </header>
+
+        <!-- ============ THE SEAM (lead) ============ -->
+        <section class="space-y-5">
+          <h2 class="text-2xl font-serif font-semibold">
+            The seam: what you supply, what the substrate owns
+          </h2>
+          <p class="text-sm text-slate-600 max-w-3xl">
+            This is the one idea to hold onto. The runners are <strong>pure orchestration</strong> —
+            they never touch your store or event log. You hand them a description of your entity and
+            a strategy for writing results back; they hand you suggestions, auto-applied values, and
+            trace records. Every I/O boundary stays in your code (ADR&nbsp;0017, ADR&nbsp;0020).
+          </p>
+          <div class="rounded-lg border border-slate-200 bg-white p-4">
+            <pre class="mermaid">
+flowchart LR
+  subgraph you["YOUR APP — owns I/O & review"]
+    direction TB
+    C["AiContract / IngestContract<br/><span style='font-size:11px'>schema · fields · presets</span>"]
+    CFG["AiConfig<br/><span style='font-size:11px'>provider · model</span>"]
+    AS["assemble()<br/><span style='font-size:11px'>store + event-log writes</span>"]
+    EV["events + sinks<br/><span style='font-size:11px'>suppression · tracing</span>"]
+  end
+  subgraph sub["content-ai — owns orchestration, NO I/O"]
+    direction TB
+    R["runFill · runRefine · runRefresh"]
+  end
+  C --> R
+  CFG --> R
+  EV --> R
+  R --> AS
+  R -->|"suggestions · autoApplied · traces"| OUT["review UI / persistence"]
+  classDef deep fill:#0f172a,color:#e2e8f0,stroke:#0f172a;
+  class R deep
+            </pre>
+          </div>
+          <p class="text-xs text-slate-500">
+            Read the full picture on the
+            <a href="control-flow.html" class="text-slate-900 underline underline-offset-2"
+              >control-flow page</a
+            >.
+          </p>
+        </section>
+
+        <!-- ============ WHEN TO USE WHICH ============ -->
+        <section class="space-y-5">
+          <h2 class="text-2xl font-serif font-semibold">Which entry point?</h2>
+          <div class="rounded-lg border border-slate-200 bg-white p-4">
+            <pre class="mermaid">
+flowchart TD
+  Q{"Where does the<br/>content come from?"}
+  Q -->|"an external source<br/>(PDF, image, text, URL)"| FILL["runFill<br/><span style='font-size:11px'>content-ai-ingest</span>"]
+  Q -->|"a sibling-locale entity<br/>(translation)"| FILL
+  Q -->|"existing data + a prompt<br/>(generate / improve a field)"| REF["runRefine<br/><span style='font-size:11px'>content-ai-refine</span>"]
+  Q -->|"orchestrated full or per-field<br/>refresh, written back via a strategy"| RR["runRefresh<br/><span style='font-size:11px'>content-ai-refine</span>"]
+  RR -.drives.-> REF
+            </pre>
+          </div>
+          <div class="grid sm:grid-cols-3 gap-3 text-sm">
+            <div class="rounded-lg border border-slate-200 p-4 bg-white">
+              <p class="font-mono text-xs text-slate-400 mb-1">source-driven</p>
+              <p class="font-semibold"><code>runFill</code></p>
+              <p class="text-slate-600 text-xs mt-1">
+                Populate many fields from one artifact in a single call. Also the path for
+                translation.
+              </p>
+            </div>
+            <div class="rounded-lg border border-slate-200 p-4 bg-white">
+              <p class="font-mono text-xs text-slate-400 mb-1">prompt-driven</p>
+              <p class="font-semibold"><code>runRefine</code></p>
+              <p class="text-slate-600 text-xs mt-1">
+                Generate or improve specific fields from current data + prompts. One LLM call per
+                field.
+              </p>
+            </div>
+            <div class="rounded-lg border border-slate-200 p-4 bg-white">
+              <p class="font-mono text-xs text-slate-400 mb-1">orchestrated</p>
+              <p class="font-semibold"><code>runRefresh</code></p>
+              <p class="text-slate-600 text-xs mt-1">
+                Compute targets, drive <code>runRefine</code>, and write back through your
+                <code>assemble</code> strategy.
+              </p>
+            </div>
+          </div>
+        </section>
+
+        <!-- ============ PACKAGES ============ -->
+        <section class="space-y-5">
+          <h2 class="text-2xl font-serif font-semibold">The three packages</h2>
+          <div class="space-y-3">
+            <a
+              href="core.html"
+              class="block rounded-xl border border-slate-200 bg-white p-5 hover:border-slate-300 transition"
+            >
+              <div class="flex items-baseline justify-between gap-3 flex-wrap">
+                <p class="font-serif text-lg font-semibold">content-ai-core</p>
+                <span class="font-mono text-xs text-slate-400">imported by everything</span>
+              </div>
+              <p class="text-sm text-slate-600 mt-1">
+                The shared substrate: contract types, the append-only event log + suppression,
+                fingerprinting, the provider factory + tracing middleware (<code>/server</code>),
+                and presentation helpers. No runner of its own.
+              </p>
+            </a>
+            <a
+              href="ingest.html"
+              class="block rounded-xl border border-slate-200 bg-white p-5 hover:border-slate-300 transition"
+            >
+              <div class="flex items-baseline justify-between gap-3 flex-wrap">
+                <p class="font-serif text-lg font-semibold">content-ai-ingest</p>
+                <span class="font-mono text-xs text-slate-400">runFill</span>
+              </div>
+              <p class="text-sm text-slate-600 mt-1">
+                Source-driven fill. Turns a PDF, image, text, URL, or sibling-locale entity into
+                per-field suggestions in one model call.
+              </p>
+            </a>
+            <a
+              href="refine.html"
+              class="block rounded-xl border border-slate-200 bg-white p-5 hover:border-slate-300 transition"
+            >
+              <div class="flex items-baseline justify-between gap-3 flex-wrap">
+                <p class="font-serif text-lg font-semibold">content-ai-refine</p>
+                <span class="font-mono text-xs text-slate-400">runRefine · runRefresh</span>
+              </div>
+              <p class="text-sm text-slate-600 mt-1">
+                Prompt-driven per-field refinement and the refresh orchestration that drives it
+                through your per-kind strategy.
+              </p>
+            </a>
+          </div>
+        </section>
+
+        <!-- ============ INSTALL ============ -->
+        <section class="space-y-3">
+          <h2 class="text-2xl font-serif font-semibold">Install</h2>
+          <p class="text-sm text-slate-600">
+            Published to the GitHub Packages registry under the <code>@pixelmord</code> scope.
+          </p>
+          <pre
+            class="rounded-lg bg-slate-900 text-slate-100 text-sm p-4 overflow-x-auto"
+          ><code># .npmrc → @pixelmord:registry=https://npm.pkg.github.com
+pnpm add @pixelmord/content-ai-core \
+         @pixelmord/content-ai-ingest \
+         @pixelmord/content-ai-refine</code></pre>
+          <p class="text-xs text-slate-500">
+            <code>core</code> is a peer of both runners — install it alongside. Server-only entry
+            points (<code>/server</code>, <code>/testing</code>) use
+            <code>node:async_hooks</code> and must not be bundled for the browser.
+          </p>
+        </section>
+
+        <footer class="pt-8 border-t border-slate-200 text-xs text-slate-400">
+          content-ai · consumer docs · see also
+          <a href="api/index.html" class="underline underline-offset-2">API reference</a> and the
+          per-package READMEs for contributors.
+        </footer>
+      </main>
+    </div>
+  </body>
+</html>

--- a/docs/content-ai/ingest.html
+++ b/docs/content-ai/ingest.html
@@ -1,0 +1,182 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>content-ai-ingest — runFill</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script type="module">
+      import mermaid from "https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs";
+      mermaid.initialize({ startOnLoad: true, theme: "neutral", securityLevel: "loose" });
+    </script>
+    <style>
+      .seam {
+        stroke-dasharray: 5 4;
+      }
+      .deep {
+        background: linear-gradient(135deg, #0f172a, #1e293b);
+      }
+      .font-serif {
+        font-family: ui-serif, Georgia, Cambria, "Times New Roman", serif;
+      }
+    </style>
+  </head>
+  <body class="bg-stone-50 text-slate-900 font-sans antialiased">
+    <div class="flex min-h-screen">
+      <aside
+        class="hidden md:flex flex-col w-60 shrink-0 border-r border-slate-200 bg-white/60 px-5 py-8 sticky top-0 h-screen"
+      >
+        <p class="font-serif text-lg font-semibold"><a href="index.html">content-ai</a></p>
+        <p class="text-xs text-slate-400 mb-6">AI content substrate</p>
+        <nav class="text-sm space-y-1">
+          <a href="index.html" class="block px-2 py-1 rounded text-slate-600">Overview</a>
+          <p class="text-[11px] uppercase tracking-wider text-slate-400 pt-4 pb-1 px-2">Guides</p>
+          <a href="core.html" class="block px-2 py-1 rounded text-slate-600">core — substrate</a>
+          <a
+            href="ingest.html"
+            aria-current="page"
+            class="block px-2 py-1 rounded font-semibold text-slate-900 bg-slate-100"
+            >ingest — runFill</a
+          >
+          <a href="refine.html" class="block px-2 py-1 rounded text-slate-600"
+            >refine — runRefine / runRefresh</a
+          >
+          <p class="text-[11px] uppercase tracking-wider text-slate-400 pt-4 pb-1 px-2">Flow</p>
+          <a href="control-flow.html" class="block px-2 py-1 rounded text-slate-600"
+            >End-to-end control flow</a
+          >
+          <p class="text-[11px] uppercase tracking-wider text-slate-400 pt-4 pb-1 px-2">
+            Reference
+          </p>
+          <a
+            href="api/modules/content-ai-ingest_src.html"
+            class="block px-2 py-1 rounded text-slate-600"
+            >ingest API ↗</a
+          >
+        </nav>
+      </aside>
+
+      <main class="flex-1 max-w-4xl mx-auto px-6 py-12 space-y-14">
+        <header class="space-y-3">
+          <p class="text-xs uppercase tracking-[0.2em] text-slate-400">Guide · package</p>
+          <h1 class="text-4xl font-serif font-semibold">content-ai-ingest</h1>
+          <p class="text-lg text-slate-600 max-w-2xl">
+            One function — <code>runFill</code> — populates an entity's fields from an external
+            source in a single model call. Use it when content arrives from <em>outside</em> the
+            entity: a PDF, image, pasted text, a URL, or a sibling-locale entity to translate from.
+          </p>
+        </header>
+
+        <!-- WHEN -->
+        <section class="space-y-3">
+          <h2 class="text-2xl font-serif font-semibold">When to reach for it</h2>
+          <ul class="text-sm text-slate-700 list-disc pl-5 space-y-1 max-w-3xl">
+            <li>Importing a recipe from a scanned PDF or a photo of a label.</li>
+            <li>Seeding a draft entity from pasted text or a source URL.</li>
+            <li>Translating an entity into a new locale (a <code>SiblingLocaleSource</code>).</li>
+          </ul>
+          <p class="text-sm text-slate-600 max-w-3xl">
+            If instead you want to generate or improve a field from data already on the entity, use
+            <a href="refine.html" class="text-slate-900 underline underline-offset-2">runRefine</a>.
+          </p>
+        </section>
+
+        <!-- CONTRACT -->
+        <section class="space-y-4">
+          <h2 class="text-2xl font-serif font-semibold">The IngestContract</h2>
+          <p class="text-sm text-slate-600 max-w-3xl">
+            An <code>IngestContract</code> is the source-driven analogue of an
+            <code>AiContract</code>: a Zod <code>schema</code>, a <code>systemPrompt</code>, and a
+            <code>buildMessages</code> that turns your source context into model input (plain prompt
+            or multimodal message parts). Optional <code>fieldPolicies</code> /
+            <code>fieldConfigs</code> set per-field write and translation behavior.
+          </p>
+          <pre
+            class="rounded-lg bg-slate-900 text-slate-100 text-xs p-4 overflow-x-auto"
+          ><code>import type { IngestContract, MessageSet } from "@pixelmord/content-ai-ingest";
+
+const recipeIngest: IngestContract&lt;typeof recipeSchema, RecipeSource&gt; = {
+  schema: recipeSchema,
+  systemPrompt: "Extract a structured recipe from the supplied source.",
+  buildMessages: async (src): Promise&lt;MessageSet&gt; =&gt;
+    src.kind === "pdf-vision"
+      ? { messages: [{ role: "user", content: [{ type: "file", data: src.bytes, mediaType: "application/pdf" }] }] }
+      : { prompt: src.content },
+  fieldPolicies: { title: "fill-if-empty" },
+};</code></pre>
+        </section>
+
+        <!-- FLOW -->
+        <section class="space-y-4">
+          <h2 class="text-2xl font-serif font-semibold">What runFill does</h2>
+          <div class="rounded-lg border border-slate-200 bg-white p-4">
+            <pre class="mermaid">
+flowchart TB
+  A["runFill(params)"] --> B["contract.buildMessages(source)"]
+  B --> C["createProvider(config, sinks)"]
+  C --> D["generateText — structured output<br/>over contract.schema"]
+  D --> E["for each extracted field"]
+  E --> F{"write policy vs<br/>currentData"}
+  F -->|"may write & confident"| G["autoApplied"]
+  F -->|"needs review"| H["suggestions"]
+  E --> I["ingestedEvent<br/><span style='font-size:11px'>source attribution</span>"]
+  G --> R["RunFillResult"]
+  H --> R
+  I --> R
+  classDef deep fill:#0f172a,color:#e2e8f0,stroke:#0f172a;
+  class A,D deep
+            </pre>
+          </div>
+          <p class="text-sm text-slate-600 max-w-3xl">
+            <code>runFill</code> is side-effect free. It returns <code>suggestions</code> and
+            <code>autoApplied</code> (both keyed by field), per-call <code>traces</code>, any
+            <code>warnings</code> from message-building (e.g. a truncated PDF), and an
+            <code>ingestedEvent</code> for <em>you</em> to persist to the entity's event log.
+          </p>
+        </section>
+
+        <!-- USAGE -->
+        <section class="space-y-4">
+          <h2 class="text-2xl font-serif font-semibold">Reading the result</h2>
+          <pre
+            class="rounded-lg bg-slate-900 text-slate-100 text-xs p-4 overflow-x-auto"
+          ><code>import { runFill } from "@pixelmord/content-ai-ingest";
+
+const result = await runFill({ contract: recipeIngest, sourceContext, config });
+
+// Collapse single-valued suggestions into a draft fields record:
+const fields: Record&lt;string, unknown&gt; = {};
+for (const [field, s] of result.suggestions) {
+  if (s.kind === "single") fields[field] = s.value;
+}
+
+// Persist provenance (your I/O — the runner never writes):
+await eventLog.append(entityRef, result.ingestedEvent);</code></pre>
+          <p class="text-xs text-slate-500 max-w-3xl">
+            Adapted from <code>apps/website/src/lib/ai/ingest.ts</code>, the Spicemixer adapter.
+          </p>
+        </section>
+
+        <!-- TRANSLATION -->
+        <section class="space-y-3">
+          <h2 class="text-2xl font-serif font-semibold">Translation is a source kind</h2>
+          <p class="text-sm text-slate-600 max-w-3xl">
+            A <code>SiblingLocaleSource</code> carries the source-locale entity, the target locale,
+            and per-field hashes. Pass <code>mergeInstruction</code> (or the exported
+            <code>MERGE_INSTRUCTION</code>) to blend new translation into existing target-language
+            text rather than overwriting editor changes. <code>runRefine</code> deliberately
+            <em>rejects</em> sibling-locale sources — translation always goes through
+            <code>runFill</code>.
+          </p>
+        </section>
+
+        <footer class="pt-8 border-t border-slate-200 text-xs text-slate-400">
+          Full symbol reference:
+          <a href="api/modules/content-ai-ingest_src.html" class="underline underline-offset-2"
+            >content-ai-ingest API</a
+          >
+        </footer>
+      </main>
+    </div>
+  </body>
+</html>

--- a/docs/content-ai/ingest.html
+++ b/docs/content-ai/ingest.html
@@ -9,6 +9,19 @@
       import mermaid from "https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs";
       mermaid.initialize({ startOnLoad: true, theme: "neutral", securityLevel: "loose" });
     </script>
+    <script type="module">
+      // Syntax-highlight every code block with Shiki (loads langs/themes on demand).
+      // Mermaid blocks are `pre.mermaid` with no <code> child, so they're skipped.
+      import { codeToHtml } from "https://esm.sh/shiki@3.0.0";
+      for (const code of document.querySelectorAll("pre:not(.mermaid) > code")) {
+        const text = code.textContent ?? "";
+        const firstLine = text.trimStart().split("\n", 1)[0];
+        const lang = firstLine.startsWith("#") || /\bpnpm add\b/.test(text) ? "bash" : "tsx";
+        const html = await codeToHtml(text, { lang, theme: "github-dark" });
+        const inner = new DOMParser().parseFromString(html, "text/html").querySelector("code");
+        if (inner) code.innerHTML = inner.innerHTML;
+      }
+    </script>
     <style>
       .seam {
         stroke-dasharray: 5 4;
@@ -44,6 +57,12 @@
           <p class="text-[11px] uppercase tracking-wider text-slate-400 pt-4 pb-1 px-2">Flow</p>
           <a href="control-flow.html" class="block px-2 py-1 rounded text-slate-600"
             >End-to-end control flow</a
+          >
+          <p class="text-[11px] uppercase tracking-wider text-slate-400 pt-4 pb-1 px-2">
+            Integrate
+          </p>
+          <a href="integration.html" class="block px-2 py-1 rounded text-slate-600"
+            >Integration walkthrough</a
           >
           <p class="text-[11px] uppercase tracking-wider text-slate-400 pt-4 pb-1 px-2">
             Reference

--- a/docs/content-ai/integration.html
+++ b/docs/content-ai/integration.html
@@ -376,8 +376,10 @@ const overviewFields = [
   flow={aiFlow}                       // shares review state with the inline components
   presets={recipeContract.presets}
   onRun={async (source) =&gt; {
-    // source: { kind: "pdf" | "image" | "text" | "url", … } → your fill action → runFill
-    await aiFlow.runTranslation();    // or a bespoke action that calls runFill server-side
+    // source: { kind: "pdf" | "image" | "text" | "url", … }
+    // Hand it to your fill action, which calls runFill server-side with an IngestContract:
+    const result = await actions.aiFillRecipe({ source, locale });
+    aiFlow.ingestRefresh(result);     // reuse the same review UI as the refine path
   }}
 /&gt;</code></pre>
           <p class="text-xs text-slate-500 max-w-3xl">

--- a/docs/content-ai/integration.html
+++ b/docs/content-ai/integration.html
@@ -1,0 +1,425 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>content-ai — integration walkthrough</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script type="module">
+      import mermaid from "https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs";
+      mermaid.initialize({ startOnLoad: true, theme: "neutral", securityLevel: "loose" });
+    </script>
+    <script type="module">
+      // Syntax-highlight every code block with Shiki (loads langs/themes on demand).
+      // Mermaid blocks are `pre.mermaid` with no <code> child, so they're skipped.
+      import { codeToHtml } from "https://esm.sh/shiki@3.0.0";
+      for (const code of document.querySelectorAll("pre:not(.mermaid) > code")) {
+        const text = code.textContent ?? "";
+        const firstLine = text.trimStart().split("\n", 1)[0];
+        const lang = firstLine.startsWith("#") || /\bpnpm add\b/.test(text) ? "bash" : "tsx";
+        const html = await codeToHtml(text, { lang, theme: "github-dark" });
+        const inner = new DOMParser().parseFromString(html, "text/html").querySelector("code");
+        if (inner) code.innerHTML = inner.innerHTML;
+      }
+    </script>
+    <style>
+      .seam {
+        stroke-dasharray: 5 4;
+      }
+      .deep {
+        background: linear-gradient(135deg, #0f172a, #1e293b);
+      }
+      .font-serif {
+        font-family: ui-serif, Georgia, Cambria, "Times New Roman", serif;
+      }
+    </style>
+  </head>
+  <body class="bg-stone-50 text-slate-900 font-sans antialiased">
+    <div class="flex min-h-screen">
+      <aside
+        class="hidden md:flex flex-col w-60 shrink-0 border-r border-slate-200 bg-white/60 px-5 py-8 sticky top-0 h-screen overflow-y-auto"
+      >
+        <p class="font-serif text-lg font-semibold"><a href="index.html">content-ai</a></p>
+        <p class="text-xs text-slate-400 mb-6">AI content substrate</p>
+        <nav class="text-sm space-y-1">
+          <a href="index.html" class="block px-2 py-1 rounded text-slate-600">Overview</a>
+          <p class="text-[11px] uppercase tracking-wider text-slate-400 pt-4 pb-1 px-2">Guides</p>
+          <a href="core.html" class="block px-2 py-1 rounded text-slate-600">core — substrate</a>
+          <a href="ingest.html" class="block px-2 py-1 rounded text-slate-600">ingest — runFill</a>
+          <a href="refine.html" class="block px-2 py-1 rounded text-slate-600"
+            >refine — runRefine / runRefresh</a
+          >
+          <p class="text-[11px] uppercase tracking-wider text-slate-400 pt-4 pb-1 px-2">Flow</p>
+          <a href="control-flow.html" class="block px-2 py-1 rounded text-slate-600"
+            >End-to-end control flow</a
+          >
+          <p class="text-[11px] uppercase tracking-wider text-slate-400 pt-4 pb-1 px-2">
+            Integrate
+          </p>
+          <a
+            href="integration.html"
+            aria-current="page"
+            class="block px-2 py-1 rounded font-semibold text-slate-900 bg-slate-100"
+            >Integration walkthrough</a
+          >
+          <p class="text-[11px] uppercase tracking-wider text-slate-400 pt-4 pb-1 px-2">
+            Reference
+          </p>
+          <a href="api/index.html" class="block px-2 py-1 rounded text-slate-600"
+            >API reference ↗</a
+          >
+        </nav>
+      </aside>
+
+      <main class="flex-1 max-w-4xl mx-auto px-6 py-12 space-y-16">
+        <header class="space-y-3">
+          <p class="text-xs uppercase tracking-[0.2em] text-slate-400">Step by step</p>
+          <h1 class="text-4xl font-serif font-semibold">Integration walkthrough</h1>
+          <p class="text-lg text-slate-600 max-w-2xl">
+            Wiring a refine-and-review flow end to end: a contract, a server action that runs the
+            substrate, the <code>useAiSuggestions</code> bridge, and the registry components that
+            render the review UI. The snippets are adapted from the Spicemixer admin (recipe /
+            ingredient / pairing forms).
+          </p>
+        </header>
+
+        <!-- THREE LAYERS -->
+        <section class="space-y-5">
+          <h2 class="text-2xl font-serif font-semibold">Three layers, one boundary</h2>
+          <p class="text-sm text-slate-600 max-w-3xl">
+            An integration is three layers stacked on the
+            <a href="control-flow.html" class="text-slate-900 underline underline-offset-2">seam</a
+            >. The <strong>substrate</strong> (the npm packages) is headless and I/O-free. The
+            <strong>registry components</strong> are a copy-in UI layer — installed into your app
+            via the component registry, <em>not</em> an npm dependency — so you own and restyle
+            them. The <strong>bridge</strong> is your server action: the one place storage, the
+            event log, and the model key live.
+          </p>
+          <div class="rounded-lg border border-slate-200 bg-white p-4">
+            <pre class="mermaid">
+flowchart TB
+  subgraph ui["REGISTRY COMPONENTS — copy-in review UI (client)"]
+    direction TB
+    HOOK["useAiSuggestions(hook)"]
+    PROV["SuggestionFlowProvider"]
+    COMP["AiBulkSuggestButton · SuggestionsOverview<br/>InlineTextSuggestion · ConfidenceBadge · IngestDialog"]
+    HOOK --> PROV --> COMP
+  end
+  subgraph bridge["YOUR SERVER ACTION — the bridge (owns I/O)"]
+    direction TB
+    ACT["aiRefreshSuggestions / aiFillTranslation"]
+    ASM["assemble(): store + event-log writes"]
+    ACT --> ASM
+  end
+  subgraph sub["content-ai — substrate (NO I/O)"]
+    direction TB
+    RUN["runRefine · runFill · runRefresh"]
+  end
+  HOOK -->|"onRefine / onFill"| ACT
+  ACT --> RUN
+  RUN -->|"suggestions · autoApplied · traces · events"| ACT
+  ACT -->|"RunResult"| HOOK
+  classDef deep fill:#0f172a,color:#e2e8f0,stroke:#0f172a;
+  class RUN deep
+            </pre>
+          </div>
+        </section>
+
+        <!-- STEP 1 -->
+        <section class="space-y-4">
+          <div class="flex items-baseline gap-3">
+            <span class="font-serif text-3xl font-semibold text-slate-300">1</span>
+            <h2 class="text-2xl font-serif font-semibold">Author the contract</h2>
+          </div>
+          <p class="text-sm text-slate-600 max-w-3xl">
+            The contract is the vocabulary both layers share. A Zod <code>schema</code> defines the
+            entity; <code>fields</code> carry per-field <code>systemPrompt</code> (return
+            <code>""</code> to gate a field off), <code>bulk</code> flags (what a full refresh
+            targets), and translation behavior. Define it once, server-side, and re-export the
+            field-path type so client callsites are typo-checked.
+          </p>
+          <pre
+            class="rounded-lg bg-slate-900 text-slate-100 text-xs p-4 overflow-x-auto"
+          ><code>// src/contracts/recipeContract.ts
+import type { AiContract } from "@pixelmord/content-ai-core";
+import { recipeSchema } from "@/schemas/recipe.ts";
+
+export const recipeContract = {
+  schema: recipeSchema,
+  presets: [{ id: "tighten", label: "Tighten copy", userPrompt: "Make it concise." }],
+  fields: {
+    title:       { bulk: true, systemPrompt: (ctx) => `Improve the recipe title. ${ctx.userPrompt ?? ""}` },
+    description: { bulk: true, systemPrompt: () => "Write a one-paragraph description.",
+                   translation: { mode: "translate" } },
+    // systemPrompt returning "" gates the field off for this run:
+    notes:       { systemPrompt: (ctx) => (ctx.preset === "tighten" ? "Trim the notes." : "") },
+  },
+} satisfies AiContract&lt;typeof recipeSchema&gt;;
+
+// Field-path union → typos at callsites become TS errors.
+export type RecipeFieldPath = keyof typeof recipeContract.fields;</code></pre>
+          <p class="text-xs text-slate-500 max-w-3xl">
+            See the
+            <a href="core.html" class="text-slate-900 underline underline-offset-2">core guide</a>
+            for the full contract vocabulary.
+          </p>
+        </section>
+
+        <!-- STEP 2 -->
+        <section class="space-y-4">
+          <div class="flex items-baseline gap-3">
+            <span class="font-serif text-3xl font-semibold text-slate-300">2</span>
+            <h2 class="text-2xl font-serif font-semibold">
+              Run the substrate behind a server action
+            </h2>
+          </div>
+          <p class="text-sm text-slate-600 max-w-3xl">
+            This is the bridge — and the only place I/O happens. The action reads current data and
+            the event log, calls <code>runRefresh</code> (which drives <code>runRefine</code>),
+            persists any auto-applied writes and emitted events in your
+            <code>assemble</code> strategy, then shapes a <code>RunResult</code> for the client.
+            Server-only: <code>createProvider</code> and tracing come from <code>/server</code>.
+          </p>
+          <pre
+            class="rounded-lg bg-slate-900 text-slate-100 text-xs p-4 overflow-x-auto"
+          ><code>// src/actions/ai.ts  (Astro action / route handler — server only)
+import { runRefresh } from "@pixelmord/content-ai-refine";
+import { recipeContract } from "@/contracts/recipeContract.ts";
+
+export const aiRefreshRecipeSuggestions = defineAction({
+  handler: async ({ id, locale, payload, target }) =&gt; {
+    const result = await runRefresh({
+      contract: recipeContract,
+      currentData: payload,
+      // per-field scope: target exactly these fields, skip side-effect proposers
+      ...(target?.length ? { target } : {}),
+      config: resolveConfig(),            // provider base URL · key · model
+      events: await eventLog.read(entityRef),  // rejection history → suppression
+      // assemble is the seam: the ONLY place store + event writes happen.
+      strategy: {
+        assemble: async ({ suggestions, autoApplied, events }) =&gt; {
+          for (const ev of events) await eventLog.append(entityRef, ev);
+          for (const [field, applied] of autoApplied) await store.write(field, applied.value);
+          return { suggestions, autoApplied };
+        },
+      },
+    });
+
+    // Shape into the RunResult the client hook expects (records keyed by field).
+    return adaptToRunResult(result);  // { suggestions, autoApplied, traces, fieldSummaries }
+  },
+});</code></pre>
+          <div
+            class="rounded-md bg-amber-50 border border-amber-200 text-amber-900 text-sm px-4 py-3 max-w-3xl"
+          >
+            <span class="font-semibold">The runner never writes.</span> If you find yourself
+            reaching for the store or event log anywhere but <code>assemble</code>, the boundary has
+            leaked — see
+            <a href="control-flow.html" class="underline underline-offset-2">control flow</a>.
+          </div>
+        </section>
+
+        <!-- STEP 3 -->
+        <section class="space-y-4">
+          <div class="flex items-baseline gap-3">
+            <span class="font-serif text-3xl font-semibold text-slate-300">3</span>
+            <h2 class="text-2xl font-serif font-semibold">
+              Bridge to the UI with <code>useAiSuggestions</code>
+            </h2>
+          </div>
+          <p class="text-sm text-slate-600 max-w-3xl">
+            <code>useAiSuggestions</code> (a registry hook) holds all review state — suggestions,
+            auto-applied values, traces, per-field accessors, the overview roll-up. You feed it the
+            contract and two callbacks: <code>onRefine</code> (prompt-driven, calls your refine
+            action) and <code>onFill</code> (source-driven / translation, calls your fill action).
+            The hook passes <code>params.target</code> for per-field runs.
+          </p>
+          <pre
+            class="rounded-lg bg-slate-900 text-slate-100 text-xs p-4 overflow-x-auto"
+          ><code>// RecipeForm.tsx (client)
+import { useAiSuggestions } from "@/components/use-ai-suggestions"; // from the registry
+import { actions } from "astro:actions";
+
+const aiFlow = useAiSuggestions({
+  contract: recipeContract,
+  currentData: formValues,
+  entityRef: { kind: "recipe", id },
+  aiEventLog,                       // client-side log adapter
+  origin: { surface: "admin", action: "refine", entityKind: "recipe",
+            userInitiated: true, runId: `recipe-${id}`, triggeredBy: "editor" },
+
+  onRefine: async (params) =&gt; {
+    const { data } = await actions.aiRefreshRecipeSuggestions({
+      id, locale, payload: formValues,
+      ...(params.target?.length ? { target: params.target } : {}),
+    });
+    return data!;                   // RunResult: { suggestions, autoApplied, traces, fieldSummaries }
+  },
+
+  // Optional — only if you support source-driven fill / translation:
+  onFill: async (params) =&gt; {
+    const { data, error } = await actions.aiFillTranslation({ /* …source… */ });
+    if (error) throw new Error(error.message);
+    return data!;
+  },
+  siblingLocale: siblingLocaleData ?? undefined,  // enables translation accessors
+});</code></pre>
+        </section>
+
+        <!-- STEP 4 -->
+        <section class="space-y-4">
+          <div class="flex items-baseline gap-3">
+            <span class="font-serif text-3xl font-semibold text-slate-300">4</span>
+            <h2 class="text-2xl font-serif font-semibold">Render the registry review components</h2>
+          </div>
+          <p class="text-sm text-slate-600 max-w-3xl">
+            Wrap the form in <code>SuggestionFlowProvider</code> so the components read the flow
+            from context instead of prop-drilling. Then drop them in: a global trigger (<code
+              >AiBulkSuggestButton</code
+            >
+            with <code>overviewFields</code> renders the <code>SuggestionsOverview</code> dropdown),
+            and per-field inline components keyed by <code>fieldPath</code>. Each inline component
+            pulls its accessor via <code>useSuggestionFlowContext().forField(path)</code> —
+            accept/reject calls <code>recordAccept</code> / <code>recordReject</code>, which feed
+            the next run's suppression.
+          </p>
+          <pre
+            class="rounded-lg bg-slate-900 text-slate-100 text-xs p-4 overflow-x-auto"
+          ><code>import {
+  SuggestionFlowProvider,
+  AiBulkSuggestButton,
+  InlineTextSuggestion,
+  ConfidenceBadge,
+} from "@/components"; // copy-in registry components
+
+const overviewFields = [
+  { field: "title",       label: "Title",       anchor: "field-title" },
+  { field: "description", label: "Description", anchor: "field-description" },
+];
+
+&lt;SuggestionFlowProvider value={aiFlow}&gt;
+  {/* Global trigger + "what did the AI change?" overview */}
+  &lt;AiBulkSuggestButton overviewFields={overviewFields} /&gt;
+
+  {/* Per field — fieldPath is type-checked against RecipeFieldPath */}
+  &lt;div id="field-title"&gt;
+    &lt;label&gt;Title&lt;/label&gt;
+    &lt;input value={formValues.title} onChange={…} /&gt;
+    &lt;InlineTextSuggestion
+      fieldPath="title"
+      currentValue={formValues.title}
+      onApply={(value) =&gt; setField("title", value)}
+    /&gt;
+  &lt;/div&gt;
+&lt;/SuggestionFlowProvider&gt;</code></pre>
+          <div class="grid sm:grid-cols-2 gap-3 text-sm">
+            <div class="rounded-lg border border-slate-200 p-4 bg-white">
+              <p class="font-mono text-xs text-slate-400 mb-1">global</p>
+              <p class="font-semibold">
+                <code>AiBulkSuggestButton</code> · <code>SuggestionsOverview</code>
+              </p>
+              <p class="text-slate-600 text-xs mt-1">
+                Triggers <code>aiFlow.run()</code> and lists which fields got new suggestions —
+                including the all-duplicate case, so a run is never silently empty.
+              </p>
+            </div>
+            <div class="rounded-lg border border-slate-200 p-4 bg-white">
+              <p class="font-mono text-xs text-slate-400 mb-1">per field</p>
+              <p class="font-semibold"><code>InlineTextSuggestion</code> + siblings</p>
+              <p class="text-slate-600 text-xs mt-1">
+                <code>Inline{Text,Array,Enum,MultiEnum,Date}Suggestion</code> +
+                <code>AiFieldSuggestButton</code>. Pick by field type; all read the same per-field
+                accessor.
+              </p>
+            </div>
+            <div class="rounded-lg border border-slate-200 p-4 bg-white">
+              <p class="font-mono text-xs text-slate-400 mb-1">signal</p>
+              <p class="font-semibold">
+                <code>ConfidenceBadge</code> · <code>SuggestionTraceInfo</code>
+              </p>
+              <p class="text-slate-600 text-xs mt-1">
+                Render the suggestion's self-reported confidence and a trace link. Confidence is an
+                <em>uncalibrated</em> self-report — don't gate destructive actions on it.
+              </p>
+            </div>
+            <div class="rounded-lg border border-slate-200 p-4 bg-white">
+              <p class="font-mono text-xs text-slate-400 mb-1">source-driven</p>
+              <p class="font-semibold"><code>IngestDialog</code></p>
+              <p class="text-slate-600 text-xs mt-1">
+                The modal for the <code>runFill</code> path — see step 5.
+              </p>
+            </div>
+          </div>
+        </section>
+
+        <!-- STEP 5 -->
+        <section class="space-y-4">
+          <div class="flex items-baseline gap-3">
+            <span class="font-serif text-3xl font-semibold text-slate-300">5</span>
+            <h2 class="text-2xl font-serif font-semibold">Source-driven fill &amp; translation</h2>
+          </div>
+          <p class="text-sm text-slate-600 max-w-3xl">
+            When content comes from <em>outside</em> the entity — a PDF, image, pasted text, or a
+            sibling-locale entity to translate — the path is <code>runFill</code> behind your fill
+            action, surfaced by the registry <code>IngestDialog</code>. Pass it the same
+            <code>flow</code> (so it can show presets / write-policy and reuse the review UI) and an
+            <code>onRun</code> that triggers the call. Translation always goes through
+            <code>runFill</code> — <code>runRefine</code> rejects sibling-locale sources.
+          </p>
+          <pre
+            class="rounded-lg bg-slate-900 text-slate-100 text-xs p-4 overflow-x-auto"
+          ><code>import { IngestDialog } from "@/components";
+
+&lt;IngestDialog
+  open={open}
+  onOpenChange={setOpen}
+  flow={aiFlow}                       // shares review state with the inline components
+  presets={recipeContract.presets}
+  onRun={async (source) =&gt; {
+    // source: { kind: "pdf" | "image" | "text" | "url", … } → your fill action → runFill
+    await aiFlow.runTranslation();    // or a bespoke action that calls runFill server-side
+  }}
+/&gt;</code></pre>
+          <p class="text-xs text-slate-500 max-w-3xl">
+            On the server, the fill action mirrors step 2 but calls <code>runFill</code> with an
+            <code>IngestContract</code>; see the
+            <a href="ingest.html" class="text-slate-900 underline underline-offset-2"
+              >ingest guide</a
+            >.
+          </p>
+        </section>
+
+        <!-- CLOSING THE LOOP -->
+        <section class="space-y-4">
+          <h2 class="text-2xl font-serif font-semibold">Closing the loop</h2>
+          <p class="text-sm text-slate-600 max-w-3xl">
+            The two layers meet at the event log. When an editor rejects a suggestion, the inline
+            component's <code>recordReject</code> appends a <code>rejected</code> event; on the next
+            run your action passes those <code>events</code> into the runner, and the substrate
+            suppresses that exact fingerprint. Accepted and auto-applied writes are recorded the
+            same way. Persisting those events is a write — so it lives in your action /
+            <code>assemble</code>, never in the substrate.
+          </p>
+          <div class="rounded-lg border border-slate-200 bg-white p-4">
+            <pre class="mermaid">
+flowchart LR
+  REJ["recordReject (registry component)"] --> EV["rejected event → your event log"]
+  EV --> NEXT["next onRefine passes events"]
+  NEXT --> SUP["substrate suppresses<br/>matching fingerprint"]
+  SUP --> RUN["cleaner suggestions"]
+  classDef deep fill:#0f172a,color:#e2e8f0,stroke:#0f172a;
+  class SUP deep
+            </pre>
+          </div>
+        </section>
+
+        <footer class="pt-8 border-t border-slate-200 text-xs text-slate-400">
+          Exact signatures:
+          <a href="api/index.html" class="underline underline-offset-2">API reference</a>.
+          Per-runner detail: <a href="refine.html" class="underline underline-offset-2">refine</a> ·
+          <a href="ingest.html" class="underline underline-offset-2">ingest</a>.
+        </footer>
+      </main>
+    </div>
+  </body>
+</html>

--- a/docs/content-ai/refine.html
+++ b/docs/content-ai/refine.html
@@ -9,6 +9,19 @@
       import mermaid from "https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs";
       mermaid.initialize({ startOnLoad: true, theme: "neutral", securityLevel: "loose" });
     </script>
+    <script type="module">
+      // Syntax-highlight every code block with Shiki (loads langs/themes on demand).
+      // Mermaid blocks are `pre.mermaid` with no <code> child, so they're skipped.
+      import { codeToHtml } from "https://esm.sh/shiki@3.0.0";
+      for (const code of document.querySelectorAll("pre:not(.mermaid) > code")) {
+        const text = code.textContent ?? "";
+        const firstLine = text.trimStart().split("\n", 1)[0];
+        const lang = firstLine.startsWith("#") || /\bpnpm add\b/.test(text) ? "bash" : "tsx";
+        const html = await codeToHtml(text, { lang, theme: "github-dark" });
+        const inner = new DOMParser().parseFromString(html, "text/html").querySelector("code");
+        if (inner) code.innerHTML = inner.innerHTML;
+      }
+    </script>
     <style>
       .seam {
         stroke-dasharray: 5 4;
@@ -42,6 +55,12 @@
           <p class="text-[11px] uppercase tracking-wider text-slate-400 pt-4 pb-1 px-2">Flow</p>
           <a href="control-flow.html" class="block px-2 py-1 rounded text-slate-600"
             >End-to-end control flow</a
+          >
+          <p class="text-[11px] uppercase tracking-wider text-slate-400 pt-4 pb-1 px-2">
+            Integrate
+          </p>
+          <a href="integration.html" class="block px-2 py-1 rounded text-slate-600"
+            >Integration walkthrough</a
           >
           <p class="text-[11px] uppercase tracking-wider text-slate-400 pt-4 pb-1 px-2">
             Reference

--- a/docs/content-ai/refine.html
+++ b/docs/content-ai/refine.html
@@ -1,0 +1,190 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>content-ai-refine — runRefine / runRefresh</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script type="module">
+      import mermaid from "https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs";
+      mermaid.initialize({ startOnLoad: true, theme: "neutral", securityLevel: "loose" });
+    </script>
+    <style>
+      .seam {
+        stroke-dasharray: 5 4;
+      }
+      .deep {
+        background: linear-gradient(135deg, #0f172a, #1e293b);
+      }
+      .font-serif {
+        font-family: ui-serif, Georgia, Cambria, "Times New Roman", serif;
+      }
+    </style>
+  </head>
+  <body class="bg-stone-50 text-slate-900 font-sans antialiased">
+    <div class="flex min-h-screen">
+      <aside
+        class="hidden md:flex flex-col w-60 shrink-0 border-r border-slate-200 bg-white/60 px-5 py-8 sticky top-0 h-screen"
+      >
+        <p class="font-serif text-lg font-semibold"><a href="index.html">content-ai</a></p>
+        <p class="text-xs text-slate-400 mb-6">AI content substrate</p>
+        <nav class="text-sm space-y-1">
+          <a href="index.html" class="block px-2 py-1 rounded text-slate-600">Overview</a>
+          <p class="text-[11px] uppercase tracking-wider text-slate-400 pt-4 pb-1 px-2">Guides</p>
+          <a href="core.html" class="block px-2 py-1 rounded text-slate-600">core — substrate</a>
+          <a href="ingest.html" class="block px-2 py-1 rounded text-slate-600">ingest — runFill</a>
+          <a
+            href="refine.html"
+            aria-current="page"
+            class="block px-2 py-1 rounded font-semibold text-slate-900 bg-slate-100"
+            >refine — runRefine / runRefresh</a
+          >
+          <p class="text-[11px] uppercase tracking-wider text-slate-400 pt-4 pb-1 px-2">Flow</p>
+          <a href="control-flow.html" class="block px-2 py-1 rounded text-slate-600"
+            >End-to-end control flow</a
+          >
+          <p class="text-[11px] uppercase tracking-wider text-slate-400 pt-4 pb-1 px-2">
+            Reference
+          </p>
+          <a
+            href="api/modules/content-ai-refine_src.html"
+            class="block px-2 py-1 rounded text-slate-600"
+            >refine API ↗</a
+          >
+        </nav>
+      </aside>
+
+      <main class="flex-1 max-w-4xl mx-auto px-6 py-12 space-y-14">
+        <header class="space-y-3">
+          <p class="text-xs uppercase tracking-[0.2em] text-slate-400">Guide · package</p>
+          <h1 class="text-4xl font-serif font-semibold">content-ai-refine</h1>
+          <p class="text-lg text-slate-600 max-w-2xl">
+            Two functions. <code>runRefine</code> generates or improves fields from existing data
+            and prompts — one model call per field. <code>runRefresh</code> orchestrates a full or
+            per-field refresh on top of it, writing results back through a per-kind strategy you
+            supply.
+          </p>
+        </header>
+
+        <!-- runRefine -->
+        <section class="space-y-4">
+          <h2 class="text-2xl font-serif font-semibold">runRefine — the per-field funnel</h2>
+          <p class="text-sm text-slate-600 max-w-3xl">
+            Targets run concurrently. Each field passes through the same funnel; anywhere it drops
+            out, the field is simply absent from the result.
+          </p>
+          <div class="rounded-lg border border-slate-200 bg-white p-4">
+            <pre class="mermaid">
+flowchart TB
+  A["field in target set"] --> B{"writePolicy preserves<br/>an existing value?"}
+  B -->|yes| X1["skip"]
+  B -->|no| C["systemPrompt(ctx)"]
+  C --> D{"prompt empty?"}
+  D -->|yes — gated off| X2["skip"]
+  D -->|no| E["LLM → { value, confidence }"]
+  E --> F["fingerprintHash(value)"]
+  F --> G{"previously rejected?<br/>(suppression)"}
+  G -->|yes| X3["drop"]
+  G -->|no| H{"confidence ≥<br/>autoApply threshold?"}
+  H -->|yes| I["autoApplied"]
+  H -->|no| J["suggestions"]
+  classDef deep fill:#0f172a,color:#e2e8f0,stroke:#0f172a;
+  class E deep
+            </pre>
+          </div>
+          <p class="text-sm text-slate-600 max-w-3xl">
+            Confidence is the model's self-report (high=1.0, medium=0.5, low=0.0) — an uncalibrated
+            hint, not a logprob. The result is
+            <code>{ suggestions, autoApplied, traces, errors }</code>, each keyed by field.
+            Per-field errors are collected by default; pass <code>errorMode: "throw"</code> for
+            single-field editor calls that should surface failure.
+          </p>
+        </section>
+
+        <!-- runRefresh -->
+        <section class="space-y-4">
+          <h2 class="text-2xl font-serif font-semibold">
+            runRefresh — orchestration + the assemble seam
+          </h2>
+          <p class="text-sm text-slate-600 max-w-3xl">
+            <code>runRefresh</code> computes the target field set (a full run = the missing
+            recommended fields plus every <code>bulk</code> field the contract declares; a per-field
+            run = exactly what you asked for), drives <code>runRefine</code>, gates on errors, then
+            hands everything to your <code>assemble</code>.
+            <strong>All store and event-log I/O lives in <code>assemble</code></strong> — the runner
+            stays portable across consumers.
+          </p>
+          <div class="rounded-lg border border-slate-200 bg-white p-4">
+            <pre class="mermaid">
+flowchart LR
+  P["params: baseFields,<br/>isPerField, config"] --> T["compute target<br/>(+ bulk fields)"]
+  S["RefreshStrategy<br/>contract · currentData ·<br/>sourceContext · events"] --> T
+  T --> RF["runField (= runRefine)"]
+  RF --> EG{"errors &amp; no<br/>suggestions?"}
+  EG -->|yes| TH["throw"]
+  EG -->|no| EX["extract rawImprovements"]
+  EX --> AS["strategy.assemble(...)"]
+  AS --> RES["your Result<br/><span style='font-size:11px'>writes store + events</span>"]
+  classDef deep fill:#0f172a,color:#e2e8f0,stroke:#0f172a;
+  classDef seam fill:#fff,stroke:#475569,stroke-dasharray:5 4;
+  class RF deep
+  class AS seam
+            </pre>
+          </div>
+          <pre
+            class="rounded-lg bg-slate-900 text-slate-100 text-xs p-4 overflow-x-auto"
+          ><code>import { runRefresh } from "@pixelmord/content-ai-refine";
+
+return runRefresh(
+  {
+    contract: ingredientContract,
+    currentData: payload,
+    sourceContext: { inventory, locale },
+    events: existingEvents,
+    logger,
+    // assemble owns every side effect — store writes, event appends, filtering:
+    assemble: async ({ suggestions, autoApplied, rawImprovements, errors }) =&gt; {
+      const improvements = filterImprovements(rawImprovements);
+      // ...write autoApplied values, append events, shape your response
+      return { improvements, /* ... */ };
+    },
+  },
+  { baseFields: missingFields, isPerField: false, config },
+);</code></pre>
+          <p class="text-xs text-slate-500 max-w-3xl">
+            Adapted from <code>apps/website/src/lib/ai/runner.ts</code>. The
+            <code>runField</code> collaborator is injectable — pass a test double to exercise
+            <code>assemble</code> without an LLM.
+          </p>
+        </section>
+
+        <!-- presets & suppression -->
+        <section class="grid md:grid-cols-2 gap-4">
+          <div class="rounded-xl border border-slate-200 bg-white p-5 space-y-2">
+            <p class="font-serif text-lg font-semibold">Presets</p>
+            <p class="text-sm text-slate-600">
+              Selecting a <code>preset</code> appends its instruction to the system prompt of every
+              field that opted in via <code>presetIds</code>, and can override that field's
+              auto-apply policy. Fields that didn't opt in are skipped for that run.
+            </p>
+          </div>
+          <div class="rounded-xl border border-slate-200 bg-white p-5 space-y-2">
+            <p class="font-serif text-lg font-semibold">The suppression loop</p>
+            <p class="text-sm text-slate-600">
+              Pass the entity's <code>events</code> so a suggestion a human already rejected — same
+              field, same fingerprint — is dropped before it reaches the UI again. Reject events are
+              never pruned, so suppression is durable.
+            </p>
+          </div>
+        </section>
+
+        <footer class="pt-8 border-t border-slate-200 text-xs text-slate-400">
+          Full symbol reference:
+          <a href="api/modules/content-ai-refine_src.html" class="underline underline-offset-2"
+            >content-ai-refine API</a
+          >
+        </footer>
+      </main>
+    </div>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -16,7 +16,9 @@
   "devDependencies": {
     "@ai-hero/sandcastle": "catalog:",
     "@changesets/cli": "^2.31.0",
+    "@types/node": "catalog:",
     "@vitest/coverage-v8": "catalog:",
+    "typedoc": "catalog:",
     "vite-plus": "catalog:"
   },
   "engines": {

--- a/packages/content-ai-core/README.md
+++ b/packages/content-ai-core/README.md
@@ -2,7 +2,7 @@
 
 The shared substrate for the content-ai packages: contract vocabulary, the AI event log + suppression, fingerprinting, the provider factory with tracing, and presentation helpers. The runner packages (`content-ai-ingest`, `content-ai-refine`) depend on it; it owns the types they re-export (ADR 0017).
 
-> **Using the substrate?** See the [consumer guides](../../docs/content-ai/index.html) and the [generated API reference](../../docs/content-ai/index.html). This README is for people working **on** the package.
+> **Using the substrate?** See the [consumer guides](../../docs/content-ai/index.html) and the [generated API reference](../../docs/content-ai/api/index.html). This README is for people working **on** the package.
 
 ## Module map
 

--- a/packages/content-ai-core/README.md
+++ b/packages/content-ai-core/README.md
@@ -1,0 +1,60 @@
+# @pixelmord/content-ai-core
+
+The shared substrate for the content-ai packages: contract vocabulary, the AI event log + suppression, fingerprinting, the provider factory with tracing, and presentation helpers. The runner packages (`content-ai-ingest`, `content-ai-refine`) depend on it; it owns the types they re-export (ADR 0017).
+
+> **Using the substrate?** See the [consumer guides](../../docs/content-ai/index.html) and the [generated API reference](../../docs/content-ai/index.html). This README is for people working **on** the package.
+
+## Module map
+
+| File                               | Responsibility                                                                                                  |
+| ---------------------------------- | --------------------------------------------------------------------------------------------------------------- |
+| `contract.ts`                      | `AiContract` / `FieldConfig` / `Preset` / `PromptContext` / policies — the vocabulary consumers author against. |
+| `events.ts`                        | `AiEvent`, `AiEventLog`, stamping, pruning. Append-only history per `EntityRef`.                                |
+| `suppression.ts`                   | Filter suggestions against `rejected` events; build rejected-context prompt blocks.                             |
+| `suggestions.ts`                   | `FieldSuggestion`, `AppliedSuggestion`, `FieldWritePolicy`, `TraceSummary`.                                     |
+| `hash.ts`                          | `fingerprintHash` (short, for dedup/suppression) and `hashContent` (full, for staleness diffing).               |
+| `translation.ts` / `field-diff.ts` | `TranslationBehavior`, `resolveTranslation`, `classifyRefreshKind`.                                             |
+| `provider.ts`                      | `createProvider`, `resolveConfig`, `AiConfig`. **Server-only consumers** import via `/server`.                  |
+| `origin.ts` / `trace.ts`           | `Origin` (async-local provenance), `tracingMiddleware`, `TraceSink`. **Server-only** (`node:async_hooks`).      |
+| `logger.ts` / `errors.ts`          | Pino-compatible `Logger` interface; typed `AiError`.                                                            |
+| `presentation/`                    | Display helpers (`summarizeSuggestion`, `formatConfidence`).                                                    |
+| `testing/`                         | `InMemoryAiEventLog`, `InMemoryTraceSink`, the synthesizing mock model.                                         |
+
+### Entry points
+
+The surface is split so browser bundles never pull in Node-only code:
+
+- `.` — isomorphic: types, events, suppression, hashing, translation, logger, errors.
+- `./server` — `node:async_hooks`: Origin/ALS, tracing, `createProvider`.
+- `./testing` — in-memory log + trace sink + mock model.
+- `./presentation` — isomorphic display helpers.
+
+Keep this boundary intact: anything touching `node:async_hooks` or `process.env` belongs behind `/server` or `/testing`, never in the `.` barrel.
+
+## Develop
+
+```sh
+vp install          # after pulling
+vp pack             # build (tsdown → dist), declaration files included
+vp pack --watch     # dev
+vp test             # package tests
+vp check            # format + lint + typecheck
+```
+
+## Invariants
+
+- **One definition, no copies.** Core owns the shared types; runners re-export. The `bulk`-flag bug came from a divergent inline copy — don't reintroduce one.
+- **Never-prune events.** `rejected` and `ingested` events must stay prunable-exempt (ADR 0004): the former is the suppression record, the latter source attribution.
+- **Append serialises per `EntityRef`.** `AiEventLog.append` implementations must not interleave read-prune-write cycles for the same ref. `InMemoryAiEventLog` shows the promise-chain pattern.
+- **Fingerprint stability.** `normalizePayload` defines what counts as "the same" suggestion. Changing it invalidates existing suppression history — treat as a breaking change.
+- **No I/O in the substrate.** Core provides types and pure helpers; reads/writes live in the consumer.
+
+## Extending
+
+- **A new shared type** → add it here and re-export from the relevant runner's `types.ts`; never define it in a runner.
+- **A new trace destination** → implement `TraceSink`; wire via `createProvider({ sinks })`, not by hand.
+- **A new field policy / translation mode** → extend the union in `suggestions.ts` / `contract.ts` and handle it in both runners.
+
+## Release
+
+Published to GitHub Packages (`@pixelmord` scope, restricted). `prepublishOnly` runs the build. Version with changesets; bump runners together when the shared type surface changes.

--- a/packages/content-ai-core/src/contract.ts
+++ b/packages/content-ai-core/src/contract.ts
@@ -2,18 +2,42 @@ import type { ZodSchema, z } from "zod";
 import type { Origin } from "./origin.ts";
 import type { FieldWritePolicy } from "./suggestions.ts";
 
+/**
+ * How a field behaves when an entity is translated into a sibling locale.
+ *
+ * - `translate` — re-generate the field in the target language (default).
+ * - `copy` — carry the source value across verbatim (locale-invariant data).
+ * - `localize` — adapt rather than translate, optionally with an `instruction`.
+ * - `skip` — leave the field untouched in the target.
+ *
+ * @see {@link classifyRefreshKind} — `copy` fields refresh silently; everything
+ * else requires review.
+ */
 export type TranslationBehavior =
   | { mode: "translate" }
   | { mode: "copy" }
   | { mode: "localize"; instruction?: string }
   | { mode: "skip" };
 
+/**
+ * Whether a suggestion may be written without human review (ADR 0004).
+ *
+ * - `never` — always surface as a pending suggestion.
+ * - `high-confidence` — auto-apply when the model's self-reported confidence
+ *   score meets or exceeds `threshold` (high=1.0, medium=0.5, low=0.0).
+ */
 export type AutoApplyPolicy =
   | { policy: "never" }
   | { policy: "high-confidence"; threshold: number };
 
+/** A field name of the entity schema `S`, constrained to its string keys. */
 export type FieldPath<S extends ZodSchema> = keyof z.infer<S> & string;
 
+/**
+ * A {@link Preset} with its `instruction` already resolved to a string for the
+ * current context (presets may declare `instruction` as a function). This is
+ * the shape passed around once a preset has been selected for a run.
+ */
 export interface ResolvedPreset {
   id: string;
   label: string;
@@ -23,6 +47,10 @@ export interface ResolvedPreset {
   autoApplyOverride?: AutoApplyPolicy;
 }
 
+/**
+ * A previously rejected suggestion, surfaced into prompt context so the model
+ * can avoid re-proposing it. Built from `rejected` events in the entity's log.
+ */
 export interface RejectedSuggestion {
   fieldPath: string;
   summary: string;
@@ -30,17 +58,26 @@ export interface RejectedSuggestion {
   reason?: string;
 }
 
-// The single contract-side prompt context. Fields beyond `currentData` /
-// `sourceContext` / `userPrompt` / `preset` are optional so the field runner
-// (which only has those four) and richer callers (which also supply field,
-// rejectedSuggestions, origin) both satisfy it — this is what lets
-// content-ai-refine re-export these types instead of keeping a divergent copy.
-//
-// `currentData` is a `Partial` of the entity shape: callers routinely refine
-// against a subset of fields (e.g. just `{ name }` for slug suggestion), and
-// prompt builders already read each field defensively. This keeps those subset
-// call sites cast-free; dynamic JSON payloads (`Record<string, unknown>` read
-// from disk) still need an explicit cast since their shape isn't statically known.
+/**
+ * The argument every prompt-building function on a contract receives. A
+ * contract's `systemPrompt`, `autoApply`, and preset `instruction` callbacks
+ * all read from this to decide what to ask the model and whether to gate the
+ * field off (an empty `systemPrompt` result skips the field entirely).
+ *
+ * All fields beyond `currentData` / `sourceContext` / `userPrompt` / `preset`
+ * are optional so both the field runner (which supplies only those four) and
+ * richer callers (which also pass `field`, `rejectedSuggestions`, `origin`)
+ * satisfy the same type — this is what lets content-ai-refine re-export these
+ * types instead of keeping a divergent copy.
+ *
+ * `currentData` is a `Partial` of the entity shape: callers routinely refine a
+ * subset of fields (e.g. just `{ name }` for a slug suggestion), and prompt
+ * builders read each field defensively.
+ *
+ * @typeParam S - The entity's Zod schema.
+ * @typeParam Source - The source-context type (e.g. extracted PDF text, a
+ * sibling-locale entity); `never` when the contract has no external source.
+ */
 export interface PromptContext<S extends ZodSchema, Source = never> {
   field?: FieldPath<S>;
   currentData?: Partial<z.infer<S>>;
@@ -51,6 +88,15 @@ export interface PromptContext<S extends ZodSchema, Source = never> {
   origin?: Origin;
 }
 
+/**
+ * A named, user-selectable refinement intent (e.g. "expand", "summarize").
+ * A field opts into a preset via {@link FieldConfig.presetIds}; selecting the
+ * preset on a run appends its `instruction` to the field's system prompt and,
+ * if set, overrides the field's auto-apply policy.
+ *
+ * `instruction` may be a function so its text can depend on the current
+ * {@link PromptContext}. `appliesTo` limits which field shapes a UI offers it for.
+ */
 export interface Preset<S extends ZodSchema = ZodSchema, Source = never> {
   id: string;
   label: string;
@@ -60,28 +106,58 @@ export interface Preset<S extends ZodSchema = ZodSchema, Source = never> {
   autoApplyOverride?: AutoApplyPolicy;
 }
 
-// All AI fields are optional so contracts that only set translation
-// continue to typecheck during the migration to full field configs.
+/**
+ * Per-field AI behavior. Every property is optional so a contract can declare,
+ * say, only `translation` for a field and still typecheck.
+ *
+ * The runner reads this to decide, for each field: whether to call the model
+ * (`systemPrompt` — returning `""` gates the field off), what JSON shape to ask
+ * for (`outputSchema`, falling back to the field's slice of the entity schema),
+ * whether the result may be written without review (`autoApply`), whether an
+ * existing value blocks the write (`writePolicy`), and how the field behaves
+ * under translation (`translation`).
+ */
 export interface FieldConfig<S extends ZodSchema = ZodSchema, Source = never> {
+  /**
+   * Builds the system prompt for this field. Returning an empty/whitespace
+   * string gates the field off for the current context — the runner skips it
+   * silently (e.g. "no inventory → no pairings"). Put preconditions here, not
+   * in {@link FieldConfig.bulk}.
+   */
   systemPrompt?: (ctx: PromptContext<S, Source>) => string;
-  // Custom schema for LLM structured output. When omitted, the runner extracts
-  // the field's schema from the entity schema. Use when the LLM output shape
-  // differs from the stored entity shape (e.g. includes a confidence score).
+  /**
+   * Custom schema for the LLM's structured output. When omitted, the runner
+   * extracts the field's schema from the entity schema. Use when the LLM output
+   * shape differs from the stored entity shape.
+   */
   outputSchema?: ZodSchema;
+  /** Auto-apply policy for this field; may depend on the prompt context. */
   autoApply?: AutoApplyPolicy | ((ctx: PromptContext<S, Source>) => AutoApplyPolicy);
+  /** Ids of {@link Preset}s this field participates in. */
   presetIds?: string[];
+  /** Whether an existing value blocks/merges the suggested write. */
   writePolicy?: FieldWritePolicy<unknown>;
+  /** How this field behaves when the entity is translated. */
   translation?: TranslationBehavior;
-  // When true, this field is attempted on every all-fields ("bulk") refresh,
-  // not only when it is among the missing recommended fields. This is the
-  // single source of truth for which enrichment fields a full run produces —
-  // the runner derives its bulk target from the contract rather than a
-  // hand-maintained per-entity list. Fields whose `systemPrompt` returns ""
-  // for the current context are skipped by the runner, so preconditions
-  // (e.g. "no inventory → no pairings") belong in the prompt, not here.
+  /**
+   * When `true`, this field is attempted on every all-fields ("bulk") refresh,
+   * not only when it is among the missing recommended fields. The contract is
+   * thus the single source of truth for which enrichment fields a full run
+   * produces — the runner derives its bulk target from here rather than a
+   * hand-maintained per-entity list.
+   */
   bulk?: boolean;
 }
 
+/**
+ * The complete description of how AI fills and refines one entity kind. The
+ * central object a consumer authors and passes to the runners: the Zod `schema`
+ * defines the entity shape, `fields` configures per-field AI behavior, and
+ * `presets` lists the refinement intents the UI can offer.
+ *
+ * @typeParam S - The entity's Zod schema.
+ * @typeParam Source - The external source-context type, or `never` if none.
+ */
 export interface AiContract<S extends ZodSchema, Source = never> {
   schema: S;
   presets: Preset<S, Source>[];

--- a/packages/content-ai-core/src/errors.ts
+++ b/packages/content-ai-core/src/errors.ts
@@ -1,3 +1,4 @@
+/** Machine-readable category for an {@link AiError}. */
 export type AiErrorCode =
   | "NOT_CONFIGURED"
   | "EXTRACTION_FAILED"
@@ -5,6 +6,7 @@ export type AiErrorCode =
   | "FILE_TOO_LARGE"
   | "UNSUPPORTED_TYPE";
 
+/** Optional diagnostic detail attached to an {@link AiError}. */
 export interface AiErrorDetails {
   /** Raw text returned by the model (when available — e.g. on schema validation failure). */
   rawText?: string;
@@ -18,6 +20,10 @@ export interface AiErrorDetails {
   cause?: string;
 }
 
+/**
+ * Typed error for AI operations, carrying a machine-readable {@link AiErrorCode}
+ * and optional {@link AiErrorDetails} (raw model text, finish reason, usage).
+ */
 export class AiError extends Error {
   constructor(
     public readonly code: AiErrorCode,

--- a/packages/content-ai-core/src/events.ts
+++ b/packages/content-ai-core/src/events.ts
@@ -1,10 +1,16 @@
 import { z } from "zod";
 
+/**
+ * Identifies one content entity across the substrate: its `kind`
+ * (e.g. "recipe") and a `kind`-scoped `id`. The key for event-log reads and
+ * the discriminator the consumer keys per-kind behavior off.
+ */
 export interface EntityRef {
   kind: string;
   id: string;
 }
 
+/** Zod schema for {@link SourceDescriptor}. */
 export const sourceDescriptorSchema = z.object({
   kind: z.enum(["pdf", "image", "text", "url"]),
   url: z.string().optional(),
@@ -17,8 +23,19 @@ export const sourceDescriptorSchema = z.object({
   traceId: z.string().optional(),
 });
 
+/**
+ * Provenance for an AI fill: what artifact the content was extracted from
+ * (a PDF, image, pasted text, or URL), its hash/mime/size, and the model and
+ * trace used. Recorded on `ingested` events for source attribution (ADR 0012).
+ */
 export type SourceDescriptor = z.infer<typeof sourceDescriptorSchema>;
 
+/**
+ * Coerce a loose source value into a {@link SourceDescriptor}. A bare string is
+ * treated as a URL; an existing descriptor passes through; `undefined` stays
+ * `undefined`. Lets callers record provenance without constructing the full
+ * descriptor by hand.
+ */
 export function normalizeSourceField(
   source: string | SourceDescriptor | undefined,
 ): SourceDescriptor | undefined {
@@ -36,6 +53,7 @@ export function normalizeSourceField(
   return source;
 }
 
+/** Zod schema for {@link AiEvent}; use to validate persisted event records. */
 export const aiEventSchema = z.object({
   id: z.string(),
   type: z.enum(["auto-applied", "accepted", "rejected", "ingested"]),
@@ -52,6 +70,13 @@ export const aiEventSchema = z.object({
   traceId: z.string().optional(),
 });
 
+/**
+ * One entry in an entity's append-only AI history. Records that a suggestion
+ * was `auto-applied`, `accepted`, `rejected`, or that content was `ingested`
+ * from a source. `rejected` events drive suppression (a re-proposed identical
+ * suggestion is filtered); `ingested` events carry source attribution. Both are
+ * never pruned. Core stamps `id` and `at`.
+ */
 export type AiEvent = z.infer<typeof aiEventSchema>;
 
 /**
@@ -70,14 +95,21 @@ export interface AiEventLog {
   append(ref: EntityRef, event: Omit<AiEvent, "at" | "id">): Promise<void>;
 }
 
-// ADR 0004: rejected and ingested events are NEVER prunable — they form the
-// suppression history and source-attribution record respectively.
+/**
+ * Whether an event may be dropped when trimming a log to its cap. `rejected`
+ * and `ingested` events are never prunable (ADR 0004) — they form the
+ * suppression history and source-attribution record respectively.
+ */
 export function isPrunable(event: AiEvent): boolean {
   return event.type !== "rejected" && event.type !== "ingested";
 }
 
-// Returns the events to KEEP after pruning to capHint. Priority: oldest
-// auto-applied pruned first, then oldest accepted.
+/**
+ * Compute the events to KEEP after trimming `events` down toward `capHint`.
+ * Pure — does not mutate. Drops oldest `auto-applied` first, then oldest
+ * `accepted`; never drops `rejected`/`ingested`. Returns the input unchanged
+ * when already at or under the cap.
+ */
 export function planPrune(events: AiEvent[], capHint = 100): AiEvent[] {
   if (events.length <= capHint) return events;
 
@@ -92,10 +124,15 @@ export function planPrune(events: AiEvent[], capHint = 100): AiEvent[] {
   return events.filter((e) => !toRemove.has(e));
 }
 
+/** {@link planPrune} at the default cap of 100, returning the events to keep. */
 export function prune(events: AiEvent[]): AiEvent[] {
   return planPrune(events, 100);
 }
 
+/**
+ * Return a copy of `meta` with `event` appended to its `aiEvents` and the list
+ * pruned to cap. Immutable — does not mutate the input meta.
+ */
 export function appendEvent<M extends { aiEvents?: AiEvent[] }>(
   meta: M,
   event: AiEvent,
@@ -104,14 +141,20 @@ export function appendEvent<M extends { aiEvents?: AiEvent[] }>(
   return { ...meta, aiEvents: prune([...current, event]) } as M & { aiEvents: AiEvent[] };
 }
 
+/** Stamp a new `id` (`crypto.randomUUID()`) and `at` (ISO now) onto an event. */
 export function createAiEvent(params: Omit<AiEvent, "id" | "at">): AiEvent {
   return { ...params, id: crypto.randomUUID(), at: new Date().toISOString() };
 }
 
+/**
+ * Stamp and append an event to an in-memory list, returning a new pruned array.
+ * Convenience over {@link createAiEvent} + {@link prune} for the common case.
+ */
 export function recordAiEvent(events: AiEvent[], params: Omit<AiEvent, "at" | "id">): AiEvent[] {
   return prune([...events, createAiEvent(params)]);
 }
 
+/** Whether the log already has an `auto-applied` event for `field`. */
 export function hasAutoApplied(events: AiEvent[], field: string): boolean {
   return events.some((e) => e.type === "auto-applied" && e.field === field);
 }

--- a/packages/content-ai-core/src/field-diff.ts
+++ b/packages/content-ai-core/src/field-diff.ts
@@ -1,5 +1,10 @@
 import type { FieldConfig } from "./contract.ts";
 
+/**
+ * Field names whose content hash differs between `current` and a prior
+ * `snapshot` (sorted). Drives detection of which fields went stale since the
+ * last AI fill, e.g. for deciding what a translation refresh must re-run.
+ */
 export function diffFieldHashes(
   current: Record<string, string>,
   snapshot: Record<string, string>,
@@ -12,8 +17,18 @@ export function diffFieldHashes(
   return changed.sort();
 }
 
+/**
+ * Whether a refresh can be applied without review. `silent` when every stale
+ * field is locale-invariant (`copy`); `review-required` otherwise.
+ */
 export type RefreshKind = "silent" | "review-required";
 
+/**
+ * Classify a set of `staleFields` against their contract configs: returns
+ * `silent` only if all stale fields use `{ mode: "copy" }` translation,
+ * else `review-required`. Used to decide whether a sibling-locale refresh can
+ * auto-apply or must surface for human review.
+ */
 export function classifyRefreshKind(
   staleFields: string[],
   fieldConfig: Record<string, FieldConfig>,

--- a/packages/content-ai-core/src/hash.ts
+++ b/packages/content-ai-core/src/hash.ts
@@ -1,6 +1,12 @@
 import { sha256 } from "@noble/hashes/sha256";
 import { bytesToHex } from "@noble/hashes/utils";
 
+/**
+ * Canonicalize a value to a stable string before hashing: strings are trimmed
+ * and lowercased, object keys sorted, arrays recursed. Ensures cosmetically
+ * different inputs (key order, casing, whitespace) hash identically — the basis
+ * for fingerprint-based dedup and suppression.
+ */
 export function normalizePayload(value: unknown): string {
   if (typeof value === "string") return value.trim().toLowerCase();
   if (Array.isArray(value)) return JSON.stringify(value.map(normalizePayload));
@@ -15,13 +21,23 @@ export function normalizePayload(value: unknown): string {
   return JSON.stringify(value);
 }
 
-// First 12 hex chars of SHA-256 over the normalised field value.
+/**
+ * Short fingerprint of a value: the first 12 hex chars of SHA-256 over its
+ * {@link normalizePayload | normalized} form. Used to identify a suggestion for
+ * dedup and suppression — collisions are acceptable at this length for that use.
+ */
 export function fingerprintHash(payload: unknown): string {
   return bytesToHex(sha256(normalizePayload(payload))).slice(0, 12);
 }
 
+/** Alias of {@link fingerprintHash}, named for the suggestion-hashing use site. */
 export const hashSuggestion = fingerprintHash;
 
+/**
+ * Full-length SHA-256 hex over a normalized record. Used for content
+ * fingerprinting (e.g. per-field hashes that drive stale-field diffing), where
+ * collision resistance matters more than brevity.
+ */
 export function hashContent(record: unknown): string {
   return bytesToHex(sha256(normalizePayload(record)));
 }

--- a/packages/content-ai-core/src/logger.ts
+++ b/packages/content-ai-core/src/logger.ts
@@ -1,11 +1,14 @@
-// Structural logger interface — pino-compatible, no runtime dependency.
-// Consumers pass any logger that matches this shape (pino, bunyan, custom).
-
+/** A single log method: accepts a message, or a structured object + message. */
 export interface LogFn {
   (msg: string): void;
   (obj: unknown, msg?: string): void;
 }
 
+/**
+ * Structural logger interface — pino-compatible, no runtime dependency.
+ * Consumers pass any logger matching this shape (pino, bunyan, custom); the
+ * runners default to {@link noopLogger} when none is supplied.
+ */
 export interface Logger {
   trace: LogFn;
   debug: LogFn;
@@ -18,6 +21,7 @@ export interface Logger {
 
 const noop: LogFn = (() => {}) as LogFn;
 
+/** A {@link Logger} that discards everything. The runners' default. */
 export const noopLogger: Logger = {
   trace: noop,
   debug: noop,
@@ -29,6 +33,7 @@ export const noopLogger: Logger = {
 };
 
 const LEVELS = { trace: 10, debug: 20, info: 30, warn: 40, error: 50, fatal: 60 } as const;
+/** Log severity name, ordered `trace` < `debug` < … < `fatal`. */
 export type LogLevel = keyof typeof LEVELS;
 
 /**

--- a/packages/content-ai-core/src/origin.ts
+++ b/packages/content-ai-core/src/origin.ts
@@ -1,5 +1,14 @@
 import { AsyncLocalStorage } from "node:async_hooks";
 
+/**
+ * Ambient provenance for an AI run: which `surface`/`action` triggered it,
+ * which entity/field it targets, whether a user initiated it, and the `runId`
+ * correlating all LLM calls in the run. Carried through
+ * {@link originContext | async-local storage} so {@link tracingMiddleware} can
+ * stamp every emitted {@link TraceEvent} without threading it manually.
+ *
+ * Server-only (`node:async_hooks`).
+ */
 export interface Origin {
   surface: string;
   action: string;
@@ -14,14 +23,23 @@ export interface Origin {
   sourceHash?: string;
 }
 
+/** The `AsyncLocalStorage` holding the current {@link Origin} for a run. */
 export const originContext = new AsyncLocalStorage<Origin>();
 
+/** Run `fn` with `origin` set as the ambient {@link Origin}, returning its result. */
 export function withOrigin<T>(origin: Origin, fn: () => T | PromiseLike<T>): Promise<T> {
   return Promise.resolve(originContext.run(origin, fn));
 }
 
+/** {@link Origin} without `runId` — {@link wrapWithOrigin} fills it if omitted. */
 export type OriginConfig = Omit<Origin, "runId"> & { runId?: string };
 
+/**
+ * Wrap an async handler so every invocation runs inside a fresh {@link Origin}
+ * (a generated `runId` unless `config.runId` is given). The returned decorator
+ * preserves the handler's signature — use it to attach provenance at a request
+ * or action boundary so downstream LLM calls are traced under one run.
+ */
 export function wrapWithOrigin(
   config: OriginConfig,
 ): <A extends unknown[], R>(handler: (...a: A) => Promise<R>) => (...a: A) => Promise<R> {
@@ -33,6 +51,7 @@ export function wrapWithOrigin(
   };
 }
 
+/** The ambient {@link Origin} for the current run, or `undefined` outside one. */
 export function getCurrentOrigin(): Origin | undefined {
   return originContext.getStore();
 }

--- a/packages/content-ai-core/src/presentation/index.ts
+++ b/packages/content-ai-core/src/presentation/index.ts
@@ -1,5 +1,9 @@
 import type { FieldSuggestion } from "../suggestions.ts";
 
+/**
+ * Human-readable one-liner for a {@link FieldSuggestion}: the stored `summary`
+ * for a single value, or a "N candidates (pick …)" line for a choice.
+ */
 export function summarizeSuggestion(suggestion: FieldSuggestion): string {
   if (suggestion.kind === "single") {
     return suggestion.summary;
@@ -11,6 +15,7 @@ export function summarizeSuggestion(suggestion: FieldSuggestion): string {
   return `${count} candidates (${pickLabel})`;
 }
 
+/** Title-case a confidence level for display ("high" → "High"). */
 export function formatConfidence(confidence: "high" | "medium" | "low"): string {
   switch (confidence) {
     case "high":
@@ -22,6 +27,7 @@ export function formatConfidence(confidence: "high" | "medium" | "low"): string 
   }
 }
 
+/** Convert a runner's `suggestions` Map into a plain field-keyed object for rendering. */
 export function groupSuggestionsByField(
   suggestions: Map<string, FieldSuggestion>,
 ): Record<string, FieldSuggestion> {

--- a/packages/content-ai-core/src/provider.ts
+++ b/packages/content-ai-core/src/provider.ts
@@ -6,12 +6,22 @@ import { createMockLanguageModel } from "./testing/mock-model.ts";
 import type { TraceSink } from "./trace.ts";
 import { tracingMiddleware } from "./trace.ts";
 
+/**
+ * Connection settings for the LLM provider: OpenAI-compatible `baseUrl`,
+ * `apiKey`, and the `model` id. Passed to every runner and to
+ * {@link createProvider}.
+ */
 export interface AiConfig {
   baseUrl: string;
   apiKey: string;
   model: string;
 }
 
+/**
+ * Build an {@link AiConfig} from environment variables — `AI_BASE_URL`,
+ * `AI_API_KEY` (or `OPENAI_API_KEY`), `AI_MODEL` — with OpenAI defaults.
+ * Convenience for server entrypoints; consumers may construct config directly.
+ */
 export function resolveConfig(): AiConfig {
   return {
     baseUrl: process.env["AI_BASE_URL"] ?? "https://api.openai.com/v1",
@@ -20,14 +30,28 @@ export function resolveConfig(): AiConfig {
   };
 }
 
+/** Options for {@link createProvider}: optional trace `sinks` to wrap the model with. */
 export interface ProviderOptions {
   sinks?: TraceSink[];
 }
 
+/**
+ * Default `providerOptions` passed to the AI SDK. Spread this and override per
+ * call (the refine runner flips `strictJsonSchema` on for structured output).
+ */
 export const PROVIDER_OPTIONS = {
   openai: { strictJsonSchema: false },
 } as const;
 
+/**
+ * Construct a `LanguageModel` from {@link AiConfig}. When `AI_PROVIDER=mock` is
+ * set, returns the synthesizing mock model (for e2e) instead of a real OpenAI
+ * client. When `sinks` are supplied, wraps the model with
+ * {@link tracingMiddleware} so each call emits a {@link TraceEvent}.
+ *
+ * Server-only: exported from `@pixelmord/content-ai-core/server` because the
+ * tracing path depends on `node:async_hooks`.
+ */
 export function createProvider(config: AiConfig, options?: ProviderOptions): LanguageModel {
   const sinks = options?.sinks;
   const wrap = (model: LanguageModelV3): LanguageModel =>

--- a/packages/content-ai-core/src/suggestions.ts
+++ b/packages/content-ai-core/src/suggestions.ts
@@ -1,3 +1,13 @@
+/**
+ * How a suggested value interacts with an existing field value.
+ *
+ * - `preserve` — never overwrite; skip the field if it already has a value.
+ * - `replace` — always overwrite.
+ * - `fill-if-empty` — write only when the field is empty (default when current
+ *   data is present).
+ * - `merge-function` — combine current and proposed with a caller-supplied fn.
+ * - `merge-instructions` — ask the model to blend the two, guided by text.
+ */
 export type FieldWritePolicy<T = unknown> =
   | "preserve"
   | "replace"
@@ -5,6 +15,12 @@ export type FieldWritePolicy<T = unknown> =
   | { mode: "merge-function"; merge: (current: T, proposed: T) => T }
   | { mode: "merge-instructions"; instruction: string };
 
+/**
+ * A model proposal for one field, awaiting review. Either a `single` value or a
+ * `choice` of candidates the user picks from. Carries the self-reported
+ * `confidence`, a human `summary`, the content `hash` (for dedup/suppression),
+ * and the `traceId` of the LLM call that produced it.
+ */
 export type FieldSuggestion<T = unknown> =
   | {
       kind: "single";
@@ -26,6 +42,11 @@ export type FieldSuggestion<T = unknown> =
       traceId: string;
     };
 
+/**
+ * A suggestion that the runner auto-applied (its confidence met the field's
+ * {@link AutoApplyPolicy} threshold) rather than queuing for review. The
+ * consumer writes `value` and records an `auto-applied` event.
+ */
 export interface AppliedSuggestion {
   value: unknown;
   hash: string;
@@ -33,6 +54,11 @@ export interface AppliedSuggestion {
   confidence: "high" | "medium" | "low";
 }
 
+/**
+ * Metadata about a single LLM call, keyed by `traceId` in a runner's result.
+ * Records the model, wall-clock `runtimeMs`, and which preset/prompt drove it —
+ * enough to correlate a suggestion with its generation without the payload.
+ */
 export interface TraceSummary {
   traceId: string;
   model: string;

--- a/packages/content-ai-core/src/suppression.ts
+++ b/packages/content-ai-core/src/suppression.ts
@@ -1,11 +1,17 @@
 import type { AiEvent } from "./events.ts";
 
+/**
+ * Whether `(field, hash)` was previously rejected for this entity — i.e. the
+ * log has a `rejected` event with the same field and content hash. The runner
+ * checks this to drop re-proposed identical suggestions.
+ */
 export function isSuppressed(events: AiEvent[], field: string, hash: string): boolean {
   return events.some(
     (e) => e.type === "rejected" && e.field === field && e.suggestion.hash === hash,
   );
 }
 
+/** Drop any suggestions whose `(field, hash)` is {@link isSuppressed}. */
 export function filterSuggestions<T extends { field: string; hash: string }>(
   events: AiEvent[],
   suggestions: T[],
@@ -13,6 +19,11 @@ export function filterSuggestions<T extends { field: string; hash: string }>(
   return suggestions.filter((s) => !isSuppressed(events, s.field, s.hash));
 }
 
+/**
+ * Render the entity's `rejected` history as a prompt-injection block so the
+ * model can avoid re-proposing what a human already turned down. Returns `""`
+ * when nothing has been rejected.
+ */
 export function buildRejectedContext(events: AiEvent[]): string {
   const rejected = events.filter((e) => e.type === "rejected");
   if (rejected.length === 0) return "";

--- a/packages/content-ai-core/src/testing/index.ts
+++ b/packages/content-ai-core/src/testing/index.ts
@@ -9,6 +9,12 @@ function refKey(ref: EntityRef): string {
   return `${ref.kind}:${ref.id}`;
 }
 
+/**
+ * In-memory {@link AiEventLog} for tests. Serialises appends per-ref (matching
+ * the production locking contract) and adds test helpers: {@link InMemoryAiEventLog.seed | seed},
+ * {@link InMemoryAiEventLog.clear | clear}, {@link InMemoryAiEventLog.all | all}.
+ * Never use in production — state is lost on restart.
+ */
 export class InMemoryAiEventLog implements AiEventLog {
   #store = new Map<string, AiEvent[]>();
   #pending = new Map<string, Promise<void>>();
@@ -74,6 +80,10 @@ export class InMemoryAiEventLog implements AiEventLog {
   }
 }
 
+/**
+ * In-memory {@link TraceSink} for tests: collects emitted {@link TraceEvent}s
+ * on `.events` for assertions, with `.clear()` to reset.
+ */
 export class InMemoryTraceSink implements TraceSink {
   #events: TraceEvent[] = [];
 

--- a/packages/content-ai-core/src/trace.ts
+++ b/packages/content-ai-core/src/trace.ts
@@ -6,6 +6,7 @@ import type {
 import { getCurrentOrigin } from "./origin.ts";
 import type { Origin } from "./origin.ts";
 
+/** Normalized reason an LLM call ended, as recorded on a {@link TraceEvent}. */
 export type TraceFinishReason =
   | "stop"
   | "length"
@@ -15,6 +16,12 @@ export type TraceFinishReason =
   | "other"
   | "unknown";
 
+/**
+ * One fully-resolved LLM call captured by {@link tracingMiddleware}: the
+ * {@link Origin} that triggered it, model, finish reason, token usage, duration,
+ * and the request/response payloads. Emitted to every configured
+ * {@link TraceSink} for observability (ADR 0011).
+ */
 export interface TraceEvent {
   traceId: string;
   runId: string;
@@ -40,10 +47,16 @@ export interface TraceEvent {
   };
 }
 
+/**
+ * A destination for {@link TraceEvent}s. Implement `emit` to forward traces to
+ * a file, Sentry, a store, etc. Sinks are fanned out with `Promise.allSettled`,
+ * so a throwing sink never breaks the LLM call.
+ */
 export interface TraceSink {
   emit(event: TraceEvent): Promise<void> | void;
 }
 
+/** A fresh trace id (`crypto.randomUUID()`) for one LLM call. */
 export function generateTraceId(): string {
   return crypto.randomUUID();
 }
@@ -82,6 +95,14 @@ async function fan(sinks: TraceSink[], event: TraceEvent): Promise<void> {
   await Promise.allSettled(sinks.map((s) => Promise.resolve(s.emit(event))));
 }
 
+/**
+ * AI-SDK middleware that emits a {@link TraceEvent} to every `sink` for each
+ * `generate`/`stream` call, tagged with the ambient {@link Origin}. When no
+ * origin is set the call passes through untraced. Wire it via
+ * {@link createProvider}'s `sinks` option rather than by hand.
+ *
+ * Server-only (`node:async_hooks`).
+ */
 export function tracingMiddleware(sinks: TraceSink[]): LanguageModelV3Middleware {
   return {
     specificationVersion: "v3",

--- a/packages/content-ai-core/src/translation.ts
+++ b/packages/content-ai-core/src/translation.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import type { FieldConfig } from "./contract.ts";
 
+/** Zod schema for {@link TranslationBehavior}. */
 export const translationBehaviorSchema = z.discriminatedUnion("mode", [
   z.object({ mode: z.literal("translate") }),
   z.object({ mode: z.literal("copy") }),
@@ -10,6 +11,10 @@ export const translationBehaviorSchema = z.discriminatedUnion("mode", [
 
 const DEFAULT_TRANSLATION = { mode: "translate" as const };
 
+/**
+ * The effective {@link TranslationBehavior} for a field config, defaulting to
+ * `{ mode: "translate" }` when the field declares none.
+ */
 export function resolveTranslation(config: FieldConfig | undefined) {
   return config?.translation ?? DEFAULT_TRANSLATION;
 }

--- a/packages/content-ai-ingest/README.md
+++ b/packages/content-ai-ingest/README.md
@@ -1,0 +1,47 @@
+# @pixelmord/content-ai-ingest
+
+Source-driven AI fill. One runner — `runFill` — turns an external source (PDF, image, text, URL, or a sibling-locale entity) into per-field suggestions in a single structured model call.
+
+> **Using `runFill`?** See the [ingest guide](../../docs/content-ai/ingest.html) and the [API reference](../../docs/content-ai/index.html). This README is for people working **on** the package.
+
+## Module map
+
+| File          | Responsibility                                                                                                          |
+| ------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| `run-fill.ts` | `runFill` + the write-policy resolution, field-skip logic, and the `MERGE_INSTRUCTION` for sibling-locale merges.       |
+| `types.ts`    | `IngestContract`, `MessageSet`, `SiblingLocaleSource`, `RunFillParams`/`RunFillResult`. Re-exports core's shared types. |
+| `hash.ts`     | Thin re-export of core's fingerprinting (kept local to avoid a deep import).                                            |
+
+## Develop
+
+```sh
+vp install
+vp pack            # build
+vp test            # package tests
+vp check           # format + lint + typecheck
+```
+
+## Control flow
+
+`runFill` is the source-driven counterpart to `content-ai-refine`'s prompt-driven `runRefine`:
+
+1. `contract.buildMessages(source)` → a `MessageSet` (plain prompt or multimodal parts).
+2. `createProvider(config, { sinks })` → one `generateText` call with structured output over `contract.schema`.
+3. Each extracted field is split into `autoApplied` vs `suggestions` by its resolved write policy.
+4. Returns an `ingestedEvent` for the **caller** to persist — the runner writes nothing.
+
+## Invariants
+
+- **Side-effect free.** No store or event-log writes. The `ingestedEvent` is returned, not appended.
+- **Write-policy precedence** (in `resolvePolicy`): per-field `fieldPolicies` → call-level `writePolicy` → contract field policy → default (`fill-if-empty` when current data exists, else `replace`). Preserve this order — consumers depend on it.
+- **Translation goes through here, not refine.** `runRefine` rejects `SiblingLocaleSource`; sibling-locale fills (with optional `MERGE_INSTRUCTION`) are `runFill`'s job.
+- **Shared types come from core.** Don't inline `FieldWritePolicy`, `EntityRef`, etc.; re-export them from `types.ts` (ADR 0017).
+
+## Extending
+
+- **A new source kind** → handle it in the consumer's `buildMessages`; the runner is source-agnostic by design.
+- **New result data** → extend `RunFillResult` and document it in the ingest guide.
+
+## Release
+
+Published to GitHub Packages (`@pixelmord` scope, restricted). Depends on `@pixelmord/content-ai-core` (`workspace:*`); bump alongside core when the shared type surface changes.

--- a/packages/content-ai-ingest/README.md
+++ b/packages/content-ai-ingest/README.md
@@ -2,7 +2,7 @@
 
 Source-driven AI fill. One runner — `runFill` — turns an external source (PDF, image, text, URL, or a sibling-locale entity) into per-field suggestions in a single structured model call.
 
-> **Using `runFill`?** See the [ingest guide](../../docs/content-ai/ingest.html) and the [API reference](../../docs/content-ai/index.html). This README is for people working **on** the package.
+> **Using `runFill`?** See the [ingest guide](../../docs/content-ai/ingest.html) and the [API reference](../../docs/content-ai/api/index.html). This README is for people working **on** the package.
 
 ## Module map
 

--- a/packages/content-ai-ingest/src/run-fill.ts
+++ b/packages/content-ai-ingest/src/run-fill.ts
@@ -129,6 +129,23 @@ async function callLlm(
   }
 }
 
+/**
+ * Fill an entity's fields from an external source in one model call.
+ *
+ * The source-driven entry point of the substrate: given an {@link IngestContract}
+ * and a `sourceContext` (extracted PDF/image/text, or a {@link SiblingLocaleSource}
+ * for translation), it builds the contract's messages, runs the LLM, and splits
+ * the extracted per-field values into `autoApplied` writes and pending
+ * `suggestions` according to each field's write policy. Returns an
+ * `ingestedEvent` for the caller to persist as source attribution.
+ *
+ * Use this when content comes from outside the entity; use `runRefine` (in
+ * content-ai-refine) to generate/improve fields from existing data and prompts.
+ * Side-effect free: writing values and appending the event is the caller's job.
+ *
+ * @typeParam S - The entity's Zod schema.
+ * @typeParam Source - The source-context type the contract consumes.
+ */
 export async function runFill<S extends ZodSchema, Source>(
   params: RunFillParams<S, Source>,
 ): Promise<RunFillResult> {

--- a/packages/content-ai-ingest/src/types.ts
+++ b/packages/content-ai-ingest/src/types.ts
@@ -15,14 +15,23 @@ export type { AiConfig, EntityRef, FieldWritePolicy, TranslationBehavior };
 
 // ── Source-context message set ─────────────────────────────────────────────────
 
+/**
+ * The model messages a {@link IngestContract.buildMessages} call produces for a
+ * source: either prebuilt `messages` (e.g. multimodal PDF/image parts) or a
+ * plain `prompt` string, plus any `warnings` to surface (e.g. truncation).
+ */
 export interface MessageSet {
   messages?: ModelMessage[];
   prompt?: string;
   warnings?: string[];
 }
 
-// ── SiblingLocaleSource ───────────────────────────────────────────────────────
-
+/**
+ * Source context for a translation fill: an existing sibling-locale entity to
+ * generate the target locale from. `runFill` blends `sourceData` into the
+ * target language; `fieldHashes` lets the caller detect which source fields
+ * changed since the last sync.
+ */
 export interface SiblingLocaleSource<S extends ZodSchema = ZodSchema> {
   kind: "sibling-locale";
   sourceRef: EntityRef;
@@ -32,8 +41,16 @@ export interface SiblingLocaleSource<S extends ZodSchema = ZodSchema> {
   fieldHashes: Record<string, string>;
 }
 
-// ── IngestContract ────────────────────────────────────────────────────────────
-
+/**
+ * Describes how to fill one entity kind from an external source. The
+ * source-driven analogue of an `AiContract`: a Zod `schema`, a `systemPrompt`,
+ * and `buildMessages` to turn the source context into model input. Optional
+ * `fieldPolicies`/`fieldConfigs` set per-field write and translation behavior.
+ *
+ * @typeParam S - The entity's Zod schema.
+ * @typeParam Source - The source-context type (extracted artifact, or a
+ * {@link SiblingLocaleSource} for translation).
+ */
 export interface IngestContract<S extends ZodSchema, Source> {
   schema: S;
   systemPrompt: string;
@@ -44,6 +61,7 @@ export interface IngestContract<S extends ZodSchema, Source> {
 
 // ── FieldSuggestion ───────────────────────────────────────────────────────────
 
+/** A model proposal for one filled field, awaiting review. See core's `FieldSuggestion`. */
 export type FieldSuggestion<T = unknown> =
   | {
       kind: "single";
@@ -67,6 +85,7 @@ export type FieldSuggestion<T = unknown> =
 
 // ── AppliedSuggestion ─────────────────────────────────────────────────────────
 
+/** A suggestion the runner auto-applied rather than queuing. See core's `AppliedSuggestion`. */
 export interface AppliedSuggestion {
   value: unknown;
   hash: string;
@@ -74,17 +93,19 @@ export interface AppliedSuggestion {
   confidence: "high" | "medium" | "low";
 }
 
-// ── IngestTraceSummary ─────────────────────────────────────────────────────────
-// Core's TraceSummary plus the ingest-only merge prompt recorded on sibling-locale
-// fills. mergeInstruction is genuinely ingest-specific, so it extends rather than
-// pollutes the shared core type.
-
+/**
+ * Core's {@link TraceSummary} plus the ingest-only `mergeInstruction` recorded
+ * on sibling-locale fills. Extends rather than pollutes the shared core type.
+ */
 export interface IngestTraceSummary extends TraceSummary {
   mergeInstruction?: string;
 }
 
-// ── Minimal AiEvent shape for ingestedEvent ──────────────────────────────────
-
+/**
+ * The `ingested` event `runFill` returns for the caller to persist — records
+ * the source attribution (hash, summary, model, optional {@link SourceDescriptor})
+ * for the fill. Append it to the entity's event log.
+ */
 export interface IngestAiEvent {
   type: "ingested";
   at: string;
@@ -96,6 +117,12 @@ export interface IngestAiEvent {
 
 // ── RunFill params/result ─────────────────────────────────────────────────────
 
+/**
+ * Arguments to {@link runFill}: the {@link IngestContract}, the `sourceContext`
+ * to fill from, provider `config`, and optional review/trace controls. Existing
+ * `currentData` plus `writePolicy`/`fieldPolicies` govern whether a filled field
+ * overwrites an existing value.
+ */
 export interface RunFillParams<S extends ZodSchema, Source> {
   contract: IngestContract<S, Source>;
   sourceContext: Source;
@@ -120,6 +147,11 @@ export interface RunFillParams<S extends ZodSchema, Source> {
   mergeInstruction?: string;
 }
 
+/**
+ * Result of {@link runFill}: `suggestions` to review and `autoApplied` writes
+ * (both keyed by field), per-call `traces`, the `ingestedEvent` to persist, and
+ * any `warnings` accumulated while building messages.
+ */
 export interface RunFillResult {
   suggestions: Map<string, FieldSuggestion>;
   autoApplied: Map<string, AppliedSuggestion>;

--- a/packages/content-ai-refine/README.md
+++ b/packages/content-ai-refine/README.md
@@ -2,7 +2,7 @@
 
 Prompt-driven AI refinement. `runRefine` generates or improves entity fields from existing data and prompts (one model call per field); `runRefresh` orchestrates a full or per-field refresh on top of it, writing results back through a per-kind strategy the consumer supplies.
 
-> **Using these runners?** See the [refine guide](../../docs/content-ai/refine.html) and the [API reference](../../docs/content-ai/index.html). This README is for people working **on** the package.
+> **Using these runners?** See the [refine guide](../../docs/content-ai/refine.html) and the [API reference](../../docs/content-ai/api/index.html). This README is for people working **on** the package.
 
 ## Module map
 

--- a/packages/content-ai-refine/README.md
+++ b/packages/content-ai-refine/README.md
@@ -1,0 +1,45 @@
+# @pixelmord/content-ai-refine
+
+Prompt-driven AI refinement. `runRefine` generates or improves entity fields from existing data and prompts (one model call per field); `runRefresh` orchestrates a full or per-field refresh on top of it, writing results back through a per-kind strategy the consumer supplies.
+
+> **Using these runners?** See the [refine guide](../../docs/content-ai/refine.html) and the [API reference](../../docs/content-ai/index.html). This README is for people working **on** the package.
+
+## Module map
+
+| File             | Responsibility                                                                                                                          |
+| ---------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| `run-refine.ts`  | `runRefine` — the per-field funnel: write-policy skip → schema unwrap → prompt → LLM → fingerprint → suppression → auto-apply decision. |
+| `run-refresh.ts` | `runRefresh` + `RefreshStrategy` — orchestration over `runRefine`, with the `assemble` seam where consumer I/O lives (ADR 0020).        |
+| `types.ts`       | `RunRefineParams`/`RunRefineResult`, `AiEvent` (minimal), `FieldRunError`. Re-exports core's contract types.                            |
+| `hash.ts`        | Thin re-export of core's fingerprinting.                                                                                                |
+
+## Develop
+
+```sh
+vp install
+vp pack            # build
+vp test            # package tests
+vp check           # format + lint + typecheck
+```
+
+## Control flow
+
+- **`runRefine`** runs target fields concurrently. Per field, anywhere it drops out the field is simply absent from the result. The funnel: `shouldSkipByPolicy` → resolve output schema (`requireValueSchema` strips optional/nullable/default so the model must return a value) → `systemPrompt(ctx)` (empty ⇒ gated off) → `generateText` for `{ value, confidence }` → `fingerprintHash` → suppression check → `resolveAutoApply` (confidence ≥ threshold ⇒ `autoApplied`, else `suggestions`).
+- **`runRefresh`** computes the target (full run = missing `baseFields` + every `bulk` field from the contract; per-field = exactly `baseFields`), drives the injectable `runField` (default `runRefine`), gates on errors, extracts `rawImprovements`, then delegates to `strategy.assemble`.
+
+## Invariants
+
+- **The runner never touches a store or event log.** All side effects — auto-apply writes, event appends, app-specific filtering — happen in the consumer's `assemble`. This is what keeps the runner portable across consumers (ADR 0017/0020). Don't inline I/O into `run-refresh.ts`.
+- **`runField` stays an explicit seam.** It's a parameter (defaulting to `runRefine`), not a hidden module import — so tests can inject a double without an LLM.
+- **The contract decides the bulk target.** A full refresh derives its fields from `bulk: true` flags, not a hand-maintained list. Preconditions belong in a field's `systemPrompt` (return `""` to gate off), not in `bulk`.
+- **Confidence is an uncalibrated self-report**, not a logprob (high=1.0, medium=0.5, low=0.0). See the in-progress confidence work — don't treat it as a calibrated score.
+- **`runRefine` rejects sibling-locale sources.** Translation is `content-ai-ingest`'s `runFill`.
+
+## Extending
+
+- **A new orchestration shape** → add a `RefreshStrategy` field or a new `assemble` arg; keep the runner I/O-free.
+- **A new per-field behavior** → extend `FieldConfig` in core, then handle it in the funnel.
+
+## Release
+
+Published to GitHub Packages (`@pixelmord` scope, restricted). Depends on `@pixelmord/content-ai-core` (`workspace:*`); bump alongside core when the shared type surface changes.

--- a/packages/content-ai-refine/src/run-refine.ts
+++ b/packages/content-ai-refine/src/run-refine.ts
@@ -115,6 +115,23 @@ function isSiblingLocaleSource(ctx: unknown): boolean {
   );
 }
 
+/**
+ * Generate or improve entity fields from existing data and prompts — the
+ * prompt-driven counterpart to `runFill`.
+ *
+ * Runs the target fields concurrently. Per field it: skips if a write policy
+ * preserves an existing value, resolves the output schema, builds the system
+ * prompt from the contract (an empty prompt gates the field off), asks the
+ * model for `{ value, confidence }`, fingerprints the result, drops it if a
+ * matching suggestion was previously rejected, then either auto-applies it
+ * (confidence ≥ the field's threshold) or queues it as a suggestion.
+ *
+ * Rejects sibling-locale source contexts — use `runFill` for translation.
+ * Side-effect free: persisting writes/events is the caller's job.
+ *
+ * @typeParam S - The entity's Zod schema.
+ * @typeParam Source - The prompt-context source type, or `never`.
+ */
 export async function runRefine<S extends ZodSchema, Source = never>(
   params: RunRefineParams<S, Source>,
 ): Promise<RunRefineResult> {

--- a/packages/content-ai-refine/src/run-refresh.ts
+++ b/packages/content-ai-refine/src/run-refresh.ts
@@ -46,6 +46,7 @@ export interface RefreshStrategy<S extends ZodSchema, Source, Result> {
   }) => Promise<Result>;
 }
 
+/** The field-level runner {@link runRefresh} drives — {@link runRefine} by default; injectable for tests. */
 export type FieldRunner = typeof runRefine;
 
 export interface RefreshRunParams {

--- a/packages/content-ai-refine/src/types.ts
+++ b/packages/content-ai-refine/src/types.ts
@@ -30,6 +30,7 @@ export type {
 
 // ── Suggestion types ──────────────────────────────────────────────────────────
 
+/** A model proposal for one refined field, awaiting review. See core's `FieldSuggestion`. */
 export type FieldSuggestion<T = unknown> =
   | {
       kind: "single";
@@ -51,6 +52,7 @@ export type FieldSuggestion<T = unknown> =
       traceId: string;
     };
 
+/** A suggestion the runner auto-applied rather than queuing. See core's `AppliedSuggestion`. */
 export interface AppliedSuggestion {
   value: unknown;
   hash: string;
@@ -58,6 +60,7 @@ export interface AppliedSuggestion {
   confidence: "high" | "medium" | "low";
 }
 
+/** Per-call LLM metadata keyed by `traceId` in the result. See core's `TraceSummary`. */
 export interface TraceSummary {
   traceId: string;
   model: string;
@@ -67,8 +70,11 @@ export interface TraceSummary {
   confidence?: "high" | "medium" | "low";
 }
 
-// ── AiEvent (minimal, for suppression filtering) ──────────────────────────────
-
+/**
+ * Minimal AI event shape the refine runner reads for suppression — it only
+ * needs `type`/`field`/`suggestion.hash` to drop previously rejected
+ * suggestions. The full event type lives in content-ai-core.
+ */
 export interface AiEvent {
   type: "auto-applied" | "accepted" | "rejected" | "ingested";
   field?: string;
@@ -82,6 +88,12 @@ export interface AiEvent {
 
 // ── RunRefine params/result ───────────────────────────────────────────────────
 
+/**
+ * Arguments to {@link runRefine}: the {@link AiContract}, the entity's
+ * `currentData`, and what to run (`target` fields, optional `preset`/`userPrompt`).
+ * `events` supply the suppression history; `sinks` enable tracing; `errorMode`
+ * chooses collect-vs-throw for per-field failures.
+ */
 export interface RunRefineParams<S extends ZodSchema, Source = never> {
   contract: AiContract<S, Source>;
   // Partial of the entity shape: callers routinely refine a subset of fields
@@ -110,6 +122,7 @@ export interface RunRefineParams<S extends ZodSchema, Source = never> {
   errorMode?: "collect" | "throw";
 }
 
+/** A per-field failure during refinement, collected (or thrown) per `errorMode`. */
 export interface FieldRunError {
   field: string;
   message: string;
@@ -117,6 +130,10 @@ export interface FieldRunError {
   cause?: unknown;
 }
 
+/**
+ * Result of {@link runRefine}: `suggestions` to review and `autoApplied` writes
+ * (keyed by field), per-call `traces`, and per-field `errors`.
+ */
 export interface RunRefineResult {
   suggestions: Map<string, FieldSuggestion>;
   autoApplied: Map<string, AppliedSuggestion>;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -111,6 +111,9 @@ catalogs:
     tw-animate-css:
       specifier: ^1.4.0
       version: 1.4.0
+    typedoc:
+      specifier: ^0.28.19
+      version: 0.28.19
     typescript:
       specifier: ^6
       version: 6.0.3
@@ -135,9 +138,15 @@ importers:
       '@changesets/cli':
         specifier: ^2.31.0
         version: 2.31.0(@types/node@25.9.1)
+      '@types/node':
+        specifier: 'catalog:'
+        version: 25.9.1
       '@vitest/coverage-v8':
         specifier: 'catalog:'
         version: 4.1.8(vitest@4.1.8)
+      typedoc:
+        specifier: 'catalog:'
+        version: 0.28.19(typescript@6.0.3)
       vite-plus:
         specifier: 'catalog:'
         version: 0.1.24(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/coverage-v8@4.1.8)(esbuild@0.27.7)(jiti@2.6.1)(typescript@6.0.3)(vite@8.0.10(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.6.1)(yaml@2.9.0))(yaml@2.9.0)
@@ -1154,6 +1163,9 @@ packages:
 
   '@fontsource-variable/geist@5.2.8':
     resolution: {integrity: sha512-cJ6m9e+8MQ5dCYJsLylfZrgBh6KkG4bOLckB35Tr9J/EqdkEM6QllH5PxqP1dhTvFup+HtMRPuz9xOjxXJggxw==}
+
+  '@gerrit0/mini-shiki@3.23.0':
+    resolution: {integrity: sha512-bEMORlG0cqdjVyCEuU0cDQbORWX+kYCeo0kV1lbxF5bt4r7SID2l9bqsxJEM0zndaxpOUT7riCyIVEuqq/Ynxg==}
 
   '@hono/node-server@1.19.14':
     resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
@@ -2175,9 +2187,15 @@ packages:
     resolution: {integrity: sha512-fjETeq1k5ffyXqRgS6+3hpvqseLalp1kjNfRbXpUgWR8FpZ1CmQfiNHovc5lncYjt/Vg5JK/WJEmLahjwMa0og==}
     engines: {node: '>=20'}
 
+  '@shikijs/engine-oniguruma@3.23.0':
+    resolution: {integrity: sha512-1nWINwKXxKKLqPibT5f4pAFLej9oZzQTsby8942OTlsJzOBZ0MWKiwzMsd+jhzu8YPCHAswGnnN1YtQfirL35g==}
+
   '@shikijs/engine-oniguruma@4.2.0':
     resolution: {integrity: sha512-hTorK1dffPkpbMUk6Z+828PgRo7d07HbnizoP0hNPFjhxMHctj0Px/qoHeGMYafc6ju+u9iMldN4JbVzNQM++g==}
     engines: {node: '>=20'}
+
+  '@shikijs/langs@3.23.0':
+    resolution: {integrity: sha512-2Ep4W3Re5aB1/62RSYQInK9mM3HsLeB91cHqznAJMuylqjzNVAVCMnNWRHFtcNHXsoNRayP9z1qj4Sq3nMqYXg==}
 
   '@shikijs/langs@4.2.0':
     resolution: {integrity: sha512-bwrVRlJ0wUhZxAbVdvBbv2TTC9yLsh4C/IO5Ofz0T8MQntgDvyVnkbjw9vi50r1kx7RCIJdnJnjZAwmAsXFLZQ==}
@@ -2187,9 +2205,15 @@ packages:
     resolution: {integrity: sha512-NOq+DtUkVBJtZMVXL5A0vI0Xk8nvDYaXetFHSJFlOqjDZIVhIPRYFdGkSoElDqNuegikcc3A76SNUa8dTqtAYA==}
     engines: {node: '>=20'}
 
+  '@shikijs/themes@3.23.0':
+    resolution: {integrity: sha512-5qySYa1ZgAT18HR/ypENL9cUSGOeI2x+4IvYJu4JgVJdizn6kG4ia5Q1jDEOi7gTbN4RbuYtmHh0W3eccOrjMA==}
+
   '@shikijs/themes@4.2.0':
     resolution: {integrity: sha512-RX8IHYeLv8Cu2W6ruc3RxUqWn0IYCqSrMBzi/uRGAmfyDNOnNO5BF/Px7o97n4XTpmFTo5GbRaazuOWj+2ak2w==}
     engines: {node: '>=20'}
+
+  '@shikijs/types@3.23.0':
+    resolution: {integrity: sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ==}
 
   '@shikijs/types@4.2.0':
     resolution: {integrity: sha512-VT/MKtlpOhEPZloSH3Pb9WCZEBDoQVMa9jedp5UAwmJOar1DVc9DRODAxmYPW9M93IK4ryuqRejFfmlvlVDemw==}
@@ -3774,6 +3798,9 @@ packages:
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
 
+  linkify-it@5.0.1:
+    resolution: {integrity: sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg==}
+
   locate-path@5.0.0:
     resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
     engines: {node: '>=8'}
@@ -3800,6 +3827,9 @@ packages:
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
+  lunr@2.3.9:
+    resolution: {integrity: sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==}
+
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
@@ -3809,6 +3839,10 @@ packages:
   make-dir@4.0.0:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
     engines: {node: '>=10'}
+
+  markdown-it@14.2.0:
+    resolution: {integrity: sha512-1TGiQiJVRQ3NPmZH6sx5Cfnmg6GQm9jvC1ch4TK511NjSJvjzKLzn5pPfZRNZkRPZP0HqCioSndqH8v2nRaWVQ==}
+    hasBin: true
 
   markdown-table@3.0.4:
     resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
@@ -3861,6 +3895,9 @@ packages:
 
   mdn-data@2.27.1:
     resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
+
+  mdurl@2.0.0:
+    resolution: {integrity: sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==}
 
   media-typer@1.1.0:
     resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
@@ -4384,6 +4421,10 @@ packages:
   pump@3.0.4:
     resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
 
+  punycode.js@2.3.1:
+    resolution: {integrity: sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==}
+    engines: {node: '>=6'}
+
   pure-rand@6.1.0:
     resolution: {integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==}
 
@@ -4848,10 +4889,20 @@ packages:
     resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
     engines: {node: '>= 0.6'}
 
+  typedoc@0.28.19:
+    resolution: {integrity: sha512-wKh+lhdmMFivMlc6vRRcMGXeGEHGU2g8a2CkPTJjJlwRf1iXbimWIPcFolCqe4E0d/FRtGszpIrsp3WLpDB8Pw==}
+    engines: {node: '>= 18', pnpm: '>= 10'}
+    hasBin: true
+    peerDependencies:
+      typescript: 5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x || 5.7.x || 5.8.x || 5.9.x || 6.0.x
+
   typescript@6.0.3:
     resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
     hasBin: true
+
+  uc.micro@2.1.0:
+    resolution: {integrity: sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==}
 
   ufo@1.6.4:
     resolution: {integrity: sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==}
@@ -6100,6 +6151,14 @@ snapshots:
 
   '@fontsource-variable/geist@5.2.8': {}
 
+  '@gerrit0/mini-shiki@3.23.0':
+    dependencies:
+      '@shikijs/engine-oniguruma': 3.23.0
+      '@shikijs/langs': 3.23.0
+      '@shikijs/themes': 3.23.0
+      '@shikijs/types': 3.23.0
+      '@shikijs/vscode-textmate': 10.0.2
+
   '@hono/node-server@1.19.14(hono@4.12.15)':
     dependencies:
       hono: 4.12.15
@@ -6792,10 +6851,19 @@ snapshots:
       '@shikijs/vscode-textmate': 10.0.2
       oniguruma-to-es: 4.3.6
 
+  '@shikijs/engine-oniguruma@3.23.0':
+    dependencies:
+      '@shikijs/types': 3.23.0
+      '@shikijs/vscode-textmate': 10.0.2
+
   '@shikijs/engine-oniguruma@4.2.0':
     dependencies:
       '@shikijs/types': 4.2.0
       '@shikijs/vscode-textmate': 10.0.2
+
+  '@shikijs/langs@3.23.0':
+    dependencies:
+      '@shikijs/types': 3.23.0
 
   '@shikijs/langs@4.2.0':
     dependencies:
@@ -6807,9 +6875,18 @@ snapshots:
       '@shikijs/vscode-textmate': 10.0.2
       '@types/hast': 3.0.4
 
+  '@shikijs/themes@3.23.0':
+    dependencies:
+      '@shikijs/types': 3.23.0
+
   '@shikijs/themes@4.2.0':
     dependencies:
       '@shikijs/types': 4.2.0
+
+  '@shikijs/types@3.23.0':
+    dependencies:
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
 
   '@shikijs/types@4.2.0':
     dependencies:
@@ -8343,6 +8420,10 @@ snapshots:
 
   lines-and-columns@1.2.4: {}
 
+  linkify-it@5.0.1:
+    dependencies:
+      uc.micro: 2.1.0
+
   locate-path@5.0.0:
     dependencies:
       p-locate: 4.1.0
@@ -8366,6 +8447,8 @@ snapshots:
     dependencies:
       react: 19.2.7
 
+  lunr@2.3.9: {}
+
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -8379,6 +8462,15 @@ snapshots:
   make-dir@4.0.0:
     dependencies:
       semver: 7.8.1
+
+  markdown-it@14.2.0:
+    dependencies:
+      argparse: 2.0.1
+      entities: 4.5.0
+      linkify-it: 5.0.1
+      mdurl: 2.0.0
+      punycode.js: 2.3.1
+      uc.micro: 2.1.0
 
   markdown-table@3.0.4: {}
 
@@ -8507,6 +8599,8 @@ snapshots:
   mdn-data@2.0.28: {}
 
   mdn-data@2.27.1: {}
+
+  mdurl@2.0.0: {}
 
   media-typer@1.1.0: {}
 
@@ -9160,6 +9254,8 @@ snapshots:
       end-of-stream: 1.4.5
       once: 1.4.0
 
+  punycode.js@2.3.1: {}
+
   pure-rand@6.1.0: {}
 
   qs@6.15.1:
@@ -9731,7 +9827,18 @@ snapshots:
       media-typer: 1.1.0
       mime-types: 3.0.2
 
+  typedoc@0.28.19(typescript@6.0.3):
+    dependencies:
+      '@gerrit0/mini-shiki': 3.23.0
+      lunr: 2.3.9
+      markdown-it: 14.2.0
+      minimatch: 10.2.5
+      typescript: 6.0.3
+      yaml: 2.9.0
+
   typescript@6.0.3: {}
+
+  uc.micro@2.1.0: {}
 
   ufo@1.6.4: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -53,6 +53,7 @@ catalog:
   tailwind-merge: ^3.5.0
   "@astrojs/node": ^10.1.3
   "@vitejs/plugin-react": ^6.0.2
+  typedoc: ^0.28.19
 
 catalogMode: prefer
 overrides:

--- a/tsconfig.typedoc.json
+++ b/tsconfig.typedoc.json
@@ -1,0 +1,21 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "types": ["node"],
+    "skipLibCheck": true,
+    "paths": {
+      "@pixelmord/content-ai-core": ["./packages/content-ai-core/src/index.ts"],
+      "@pixelmord/content-ai-core/server": ["./packages/content-ai-core/src/server.ts"],
+      "@pixelmord/content-ai-core/presentation": [
+        "./packages/content-ai-core/src/presentation/index.ts"
+      ],
+      "@pixelmord/content-ai-core/testing": ["./packages/content-ai-core/src/testing/index.ts"]
+    }
+  },
+  "include": [
+    "packages/content-ai-core/src/**/*.ts",
+    "packages/content-ai-ingest/src/**/*.ts",
+    "packages/content-ai-refine/src/**/*.ts"
+  ],
+  "exclude": ["**/node_modules/**", "**/dist/**", "**/*.test.ts"]
+}

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://typedoc.org/schema.json",
+  "entryPoints": [
+    "packages/content-ai-core/src/index.ts",
+    "packages/content-ai-core/src/server.ts",
+    "packages/content-ai-core/src/testing/index.ts",
+    "packages/content-ai-core/src/presentation/index.ts",
+    "packages/content-ai-ingest/src/index.ts",
+    "packages/content-ai-refine/src/index.ts"
+  ],
+  "entryPointStrategy": "resolve",
+  "tsconfig": "tsconfig.typedoc.json",
+  "out": "docs/content-ai/api",
+  "name": "content-ai API reference",
+  "readme": "none",
+  "excludeInternal": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "navigationLinks": {
+    "← Guides": "../index.html"
+  },
+  "validation": {
+    "notExported": false,
+    "invalidLink": true,
+    "notDocumented": false
+  }
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -73,6 +73,16 @@ export default defineConfig({
         cwd: "apps/website",
         input: ["apps/website/src/content/**", "apps/website/src/lib/content-validators.ts"],
       },
+      "docs:api": {
+        command: "typedoc",
+        input: [
+          "packages/content-ai-core/src/**",
+          "packages/content-ai-ingest/src/**",
+          "packages/content-ai-refine/src/**",
+          "typedoc.json",
+          "tsconfig.typedoc.json",
+        ],
+      },
     },
   },
   test: {


### PR DESCRIPTION
## What

Documentation for the three `content-ai` packages, for two audiences:

- **Consumers** — styled HTML guides under `docs/content-ai/` (Tailwind + mermaid + Shiki), with sidebar nav:
  - **Overview** hub (seam-first diagram + "which entry point?" decision flow)
  - Per-package guides: **core**, **ingest** (`runFill`), **refine** (`runRefine`/`runRefresh`)
  - **End-to-end control flow** (supply-vs-owns boundary, 3 runner flows, feedback loop)
  - **Integration walkthrough** — step-by-step consumer wiring: contract → server action / `assemble` seam → `useAiSuggestions` bridge → registry review components → feedback loop
  - **API reference** — typedoc-generated from the public export surface
- **Contributors** — per-package `README.md` (module map, develop commands, invariants, extending, release).

## How

- TSDoc on every public-export symbol across the three packages.
- typedoc (`docs:api` task + `tsconfig.typedoc.json`) generates the reference into `docs/content-ai/api/` (gitignored; built in CI).
- `.github/workflows/docs.yml` builds typedoc and publishes `docs/content-ai/` to GitHub Pages on push to `main`.
- All code blocks highlighted with Shiki (github-dark) via CDN; mermaid diagrams untouched.

## Follow-ups (not in this PR)

- [ ] Enable **GitHub Pages** in repo settings (Source: GitHub Actions) for the workflow to publish.
- [ ] **Visual QA** — the guides/highlighting were authored without a working browser this session; the markup mirrors the reference design and CDN endpoints resolve, but a human render pass is recommended.
- [ ] README links are relative (render as raw source on github.com); swap to the Pages URL once Pages is live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an end-user documentation site with guides for core concepts, integration walkthroughs, ingest/refine flows, and control-flow diagrams.
  * Enabled automated API reference generation for all content-ai packages.

* **Documentation**
  * Expanded inline documentation across the codebase to clarify contracts, tracing, suppression, translation, and ingest/refine behavior.
  * Added new READMEs for core, ingest, and refine packages.

* **Chores**
  * Added an automated docs build-and-deploy pipeline and TypeDoc tooling configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->